### PR TITLE
Improve Android ID generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,15 @@ repos:
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 19.3b0
-    hooks:
-    -   id: black
 -   repo: https://github.com/PyCQA/isort
     rev: 5.7.0
     hooks:
     -   id: isort
+        args: ["--profile", "black"]
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black
+        args:
+          - --safe
+          - --quiet

--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -3,25 +3,22 @@ import logging
 from datetime import datetime
 from typing import List, Optional
 from uuid import getnode as getmac
+from uuid import uuid4
 
 import grpc
 from gpsoauth import perform_master_login, perform_oauth
-from uuid import uuid4
 
 from .const import (
-    ACCESS_TOKEN_DURATION,
     ACCESS_TOKEN_APP_NAME,
-    ACCESS_TOKEN_SERVICE,
     ACCESS_TOKEN_CLIENT_SIGNATURE,
+    ACCESS_TOKEN_DURATION,
+    ACCESS_TOKEN_SERVICE,
     ANDROID_ID_LENGTH,
     GOOGLE_HOME_FOYER_API,
     HOMEGRAPH_DURATION,
 )
-
-from .google.internal.home.foyer import v1_pb2_grpc
-from .google.internal.home.foyer import v1_pb2
-from .scanner import discover_devices, GoogleDevice
-
+from .google.internal.home.foyer import v1_pb2, v1_pb2_grpc
+from .scanner import GoogleDevice, discover_devices
 
 DEBUG = False
 

--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -1,8 +1,3 @@
-"""
-Credits to rithvikvibhu (https://github.com/rithvikvibhu)
-for implementing master and access token fetching
-See: https://gist.github.com/rithvikvibhu/952f83ea656c6782fbd0f1645059055d
-"""
 import json
 import logging
 from datetime import datetime
@@ -11,17 +6,22 @@ from uuid import getnode as getmac
 
 import grpc
 from gpsoauth import perform_master_login, perform_oauth
+from uuid import uuid4
 
-from .google.internal.home.foyer import v1_pb2, v1_pb2_grpc
-from .scanner import GoogleDevice, discover_devices
+from .const import (
+    ACCESS_TOKEN_DURATION,
+    ACCESS_TOKEN_APP_NAME,
+    ACCESS_TOKEN_SERVICE,
+    ACCESS_TOKEN_CLIENT_SIGNATURE,
+    ANDROID_ID_LENGTH,
+    GOOGLE_HOME_FOYER_API,
+    HOMEGRAPH_DURATION,
+)
 
-ACCESS_TOKEN_APP_NAME = "com.google.android.apps.chromecast.app"
-ACCESS_TOKEN_CLIENT_SIGNATURE = "24bb24c05e47e0aefa68a58a766179d9b613a600"
-ACCESS_TOKEN_SERVICE = "oauth2:https://www.google.com/accounts/OAuthLogin"
-GOOGLE_HOME_FOYER_API = "googlehomefoyer-pa.googleapis.com:443"
+from .google.internal.home.foyer import v1_pb2_grpc
+from .google.internal.home.foyer import v1_pb2
+from .scanner import discover_devices, GoogleDevice
 
-ACCESS_TOKEN_DURATION = 60 * 60
-HOMEGRAPH_DURATION = 24 * 60 * 60
 
 DEBUG = False
 
@@ -63,30 +63,16 @@ class GLocalAuthenticationTokens:
         self.homegraph_date = None
 
     @staticmethod
-    def _create_mac_string(num, splitter=":"):
-        mac = hex(num)[2:]
-        if mac[-1] == "L":
-            mac = mac[:-1]
-        pad = max(12 - len(mac), 0)
-        mac = "0" * pad + mac
-        mac = splitter.join([mac[x : x + 2] for x in range(0, 12, 2)])
-        mac = mac.upper()
-        return mac
+    def _generate_mac_string():
+        """Generate random 14 char long string"""
+        random_uuid = uuid4()
+        random_string = str(random_uuid).replace("-", "")[:ANDROID_ID_LENGTH]
+        mac_string = random_string.upper()
+        return mac_string
 
     def get_android_id(self):
         if not self.android_id:
-            mac_int = getmac()
-            if (mac_int >> 40) % 2:
-                LOGGER.error(
-                    "a valid MAC could not be determined. "
-                    "Provide an android_id (and be "
-                    "sure to provide the same one on future runs)."
-                )
-                return
-
-            android_id = self._create_mac_string(mac_int)
-            self.android_id = android_id.replace(":", "")
-        LOGGER.debug("Android ID: {}".format(self.android_id))
+            self.android_id = self._generate_mac_string()
         return self.android_id
 
     @staticmethod

--- a/glocaltokens/const.py
+++ b/glocaltokens/const.py
@@ -1,0 +1,10 @@
+ACCESS_TOKEN_APP_NAME = "com.google.android.apps.chromecast.app"
+ACCESS_TOKEN_CLIENT_SIGNATURE = "24bb24c05e47e0aefa68a58a766179d9b613a600"
+ACCESS_TOKEN_DURATION = 60 * 60
+ACCESS_TOKEN_SERVICE = "oauth2:https://www.google.com/accounts/OAuthLogin"
+
+ANDROID_ID_LENGTH = 14
+
+GOOGLE_HOME_FOYER_API = "googlehomefoyer-pa.googleapis.com:443"
+
+HOMEGRAPH_DURATION = 24 * 60 * 60

--- a/requirements
+++ b/requirements
@@ -4,6 +4,7 @@ attrs==20.3.0
 backcall==0.2.0
 bleach==3.3.0
 certifi==2020.12.5
+cfgv==3.2.0
 chardet==4.0.0
 colorama==0.4.4
 decorator==4.4.2
@@ -15,6 +16,7 @@ filelock==3.0.12
 gpsoauth==0.4.3
 grpcio==1.35.0
 grpcio-tools==1.35.0
+identify==1.5.13
 idna==2.10
 iniconfig==1.1.1
 ipdb==0.13.4
@@ -23,12 +25,14 @@ ipython-genutils==0.2.0
 jedi==0.18.0
 keyring==22.0.1
 mock==4.0.3
+nodeenv==1.5.0
 packaging==20.9
 parso==0.8.1
 pexpect==4.8.0
 pickleshare==0.7.5
 pkginfo==1.7.0
 pluggy==0.13.1
+pre-commit==2.10.1
 prompt-toolkit==3.0.14
 protobuf==3.14.0
 ptyprocess==0.7.0
@@ -37,6 +41,7 @@ pycryptodomex==3.10.1
 Pygments==2.7.4
 pyparsing==2.4.7
 python-dateutil==2.8.1
+PyYAML==5.4.1
 readme-renderer==28.0
 requests==2.25.1
 requests-toolbelt==0.9.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ from faker import Faker
 from mock import patch
 
 from glocaltokens.client import GLocalAuthenticationTokens
+from glocaltokens.const import ANDROID_ID_LENGTH
 
 faker = Faker()
 
@@ -11,7 +12,9 @@ faker = Faker()
 class GLocalAuthenticationTokensClientTests(TestCase):
     def setUp(self):
         """Setup method run before every test"""
-        pass
+        self.client = GLocalAuthenticationTokens(
+            username=faker.word(), password=faker.word()
+        )
 
     def tearDown(self):
         """Teardown method run after every test"""
@@ -64,3 +67,19 @@ class GLocalAuthenticationTokensClientTests(TestCase):
         # Without username and password
         GLocalAuthenticationTokens()
         self.assertEqual(mock.call_count, 3)
+
+    def test_get_android_id(self):
+        android_id = self.client.get_android_id()
+        self.assertTrue(len(android_id) == ANDROID_ID_LENGTH)
+
+        # Make sure we get the same ID when called further
+        self.assertEqual(android_id, self.client.get_android_id())
+
+    def test_generate_mac_string(self):
+        mac_string = GLocalAuthenticationTokens._generate_mac_string()
+        self.assertTrue(len(mac_string) == ANDROID_ID_LENGTH)
+
+        # Make sure we get different generated mac string
+        self.assertNotEqual(
+            mac_string, GLocalAuthenticationTokens._generate_mac_string()
+        )


### PR DESCRIPTION
The method which generates random android id relies on from uuid import getnode that is underlying the hardware address. On amd devices this method return 14 digits number, while on arm 15 digits long number.

Closes #21