### PR TITLE
Adding support for python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 ; envlist = py27,py36,py37,py38,py39  ; Goal to support these
-envlist = py37,py38
+envlist = py37,py38,py39
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
+    3.9: py39
 
 [testenv]
 changedir = tests


### PR DESCRIPTION
Adding support for python 3.9 to tox.ini and setting up github action.

Closes #26 