### PR TITLE
Adding client tests for fetching tokens

### DIFF
--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -145,7 +145,7 @@ class GLocalAuthenticationTokens:
         return self.android_id
 
     @staticmethod
-    def _has_expired(creation_dt, duration):
+    def _has_expired(creation_dt, duration) -> bool:
         """Checks if an specified token/object has expired"""
         return datetime.now().timestamp() - creation_dt.timestamp() > duration
 

--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -145,9 +145,9 @@ class GLocalAuthenticationTokens:
         return self.android_id
 
     @staticmethod
-    def _token_has_expired(token_date, token_duration):
-        """Checks if an specified token has expired"""
-        return datetime.now().timestamp() - token_date.timestamp() > token_duration
+    def _has_expired(creation_dt, duration):
+        """Checks if an specified token/object has expired"""
+        return datetime.now().timestamp() - creation_dt.timestamp() > duration
 
     def get_master_token(self) -> Optional[str]:
         """
@@ -165,7 +165,7 @@ class GLocalAuthenticationTokens:
         return self.master_token
 
     def get_access_token(self) -> Optional[str]:
-        if self.access_token is None or self._token_has_expired(
+        if self.access_token is None or self._has_expired(
             self.access_token_date, ACCESS_TOKEN_DURATION
         ):
             res = perform_oauth(
@@ -188,7 +188,7 @@ class GLocalAuthenticationTokens:
         """
         Returns the entire Google Home Foyer V2 service
         """
-        if self.homegraph is None or self._token_has_expired(
+        if self.homegraph is None or self._has_expired(
             self.homegraph_date, HOMEGRAPH_DURATION
         ):
             scc = grpc.ssl_channel_credentials(root_certificates=None)

--- a/tests/factory/providers.py
+++ b/tests/factory/providers.py
@@ -7,8 +7,11 @@ fake = Faker()
 
 
 class TokenProvider(BaseProvider):
-    def token_aas_et(self):
+    def master_token(self):
         return generate_token(216, prefix="aas_et/")
+
+    def access_token(self):
+        return generate_token(315, prefix="ya29.")
 
     def local_auth_token(self):
         return generate_token(108)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from unittest import TestCase
 
 from faker import Faker
@@ -5,7 +6,13 @@ from faker.providers import internet
 from mock import patch
 
 from glocaltokens.client import Device, GLocalAuthenticationTokens
-from glocaltokens.const import ANDROID_ID_LENGTH
+from glocaltokens.const import (
+    ACCESS_TOKEN_APP_NAME,
+    ACCESS_TOKEN_CLIENT_SIGNATURE,
+    ACCESS_TOKEN_DURATION,
+    ACCESS_TOKEN_SERVICE,
+    ANDROID_ID_LENGTH,
+)
 from tests.factory.mixin import TypeTestMixin
 from tests.factory.providers import TokenProvider
 
@@ -28,7 +35,7 @@ class GLocalAuthenticationTokensClientTests(TypeTestMixin, TestCase):
     def test_initialization(self):
         username = faker.word()
         password = faker.word()
-        master_token = faker.token_aas_et()
+        master_token = faker.master_token()
         android_id = faker.word()
 
         client = GLocalAuthenticationTokens(
@@ -55,41 +62,41 @@ class GLocalAuthenticationTokensClientTests(TypeTestMixin, TestCase):
         self.assertIsAASET(client.master_token)
 
     @patch("glocaltokens.client.LOGGER.error")
-    def test_initialization__valid(self, mock):
+    def test_initialization__valid(self, m_log):
         # --- GLocalAuthenticationTokens initialization --- #
         # With username and password
         GLocalAuthenticationTokens(username=faker.word(), password=faker.word())
-        self.assertEqual(mock.call_count, 0)
+        self.assertEqual(m_log.call_count, 0)
 
         # With master_token
-        GLocalAuthenticationTokens(master_token=faker.token_aas_et())
-        self.assertEqual(mock.call_count, 0)
+        GLocalAuthenticationTokens(master_token=faker.master_token())
+        self.assertEqual(m_log.call_count, 0)
 
         # --- client.Device initialization --- #
         # With ip and port
         Device(device_name=faker.word(), local_auth_token=faker.local_auth_token())
 
     @patch("glocaltokens.client.LOGGER.error")
-    def test_initialization__invalid(self, mock):
+    def test_initialization__invalid(self, m_log):
         # Without username
         GLocalAuthenticationTokens(password=faker.word())
-        self.assertEqual(mock.call_count, 1)
+        self.assertEqual(m_log.call_count, 1)
 
         # Without password
         GLocalAuthenticationTokens(username=faker.word())
-        self.assertEqual(mock.call_count, 2)
+        self.assertEqual(m_log.call_count, 2)
 
         # Without username and password
         GLocalAuthenticationTokens()
-        self.assertEqual(mock.call_count, 3)
+        self.assertEqual(m_log.call_count, 3)
 
         # With invalid master_token
         GLocalAuthenticationTokens(master_token=faker.word())
-        self.assertEqual(mock.call_count, 4)
+        self.assertEqual(m_log.call_count, 4)
 
         # Invalid local_auth_token
         Device(device_name=faker.word(), local_auth_token=faker.word())
-        self.assertEqual(mock.call_count, 5)
+        self.assertEqual(m_log.call_count, 5)
 
         # With only ip
         Device(
@@ -97,7 +104,7 @@ class GLocalAuthenticationTokensClientTests(TypeTestMixin, TestCase):
             local_auth_token=faker.local_auth_token(),
             ip=faker.ipv4_private(),
         )
-        self.assertEqual(mock.call_count, 6)
+        self.assertEqual(m_log.call_count, 6)
 
         # With only port
         Device(
@@ -105,7 +112,7 @@ class GLocalAuthenticationTokensClientTests(TypeTestMixin, TestCase):
             local_auth_token=faker.local_auth_token(),
             port=faker.port_number(),
         )
-        self.assertEqual(mock.call_count, 7)
+        self.assertEqual(m_log.call_count, 7)
 
     def test_get_android_id(self):
         android_id = self.client.get_android_id()
@@ -124,3 +131,111 @@ class GLocalAuthenticationTokensClientTests(TypeTestMixin, TestCase):
         self.assertNotEqual(
             mac_string, GLocalAuthenticationTokens._generate_mac_string()
         )
+
+    def test_has_expired(self):
+        duration_sec = 60
+        now = datetime.now()
+        token_dt__expired = now - timedelta(seconds=duration_sec + 1)
+        token_dt__non_expired = now - timedelta(seconds=duration_sec - 1)
+
+        # Expired
+        self.assertTrue(
+            GLocalAuthenticationTokens._has_expired(token_dt__expired, duration_sec)
+        )
+
+        # Non expired
+        self.assertFalse(
+            GLocalAuthenticationTokens._has_expired(token_dt__non_expired, duration_sec)
+        )
+
+    @patch("glocaltokens.client.LOGGER.error")
+    @patch("glocaltokens.client.perform_master_login")
+    def test_get_master_token(self, m_perform_master_login, m_log):
+        # No token in response
+        self.assertIsNone(self.client.get_master_token())
+        m_perform_master_login.assert_called_once_with(
+            self.client.username, self.client.password, self.client.get_android_id()
+        )
+        self.assertEqual(m_log.call_count, 1)
+
+        # Reset mocks
+        m_perform_master_login.reset_mock()
+        m_log.reset_mock()
+
+        # With token in response
+        expected_master_token = faker.master_token()
+        m_perform_master_login.return_value = {"Token": expected_master_token}
+        master_token = self.client.get_master_token()
+        m_perform_master_login.assert_called_once_with(
+            self.client.username, self.client.password, self.client.get_android_id()
+        )
+        self.assertEqual(expected_master_token, master_token)
+        self.assertEqual(m_log.call_count, 0)
+
+        # Another request - must return the same token all the time
+        master_token = self.client.get_master_token()
+        self.assertEqual(expected_master_token, master_token)
+
+    @patch("glocaltokens.client.LOGGER.error")
+    @patch("glocaltokens.client.perform_master_login")
+    @patch("glocaltokens.client.perform_oauth")
+    def test_get_access_token(self, m_perform_oauth, m_get_master_token, m_log):
+        master_token = faker.master_token()
+        m_get_master_token.return_value = {"Token": master_token}
+
+        # No token in response
+        self.assertIsNone(self.client.get_access_token())
+        m_perform_oauth.assert_called_once_with(
+            self.client.username,
+            master_token,
+            self.client.get_android_id(),
+            app=ACCESS_TOKEN_APP_NAME,
+            service=ACCESS_TOKEN_SERVICE,
+            client_sig=ACCESS_TOKEN_CLIENT_SIGNATURE,
+        )
+        self.assertEqual(m_log.call_count, 1)
+
+        # Reset mocks
+        m_perform_oauth.reset_mock()
+        m_log.reset_mock()
+
+        # With token in response
+        expected_access_token = faker.access_token()
+        m_perform_oauth.return_value = {"Auth": expected_access_token}
+        access_token = self.client.get_access_token()
+        m_perform_oauth.assert_called_once_with(
+            self.client.username,
+            master_token,
+            self.client.get_android_id(),
+            app=ACCESS_TOKEN_APP_NAME,
+            service=ACCESS_TOKEN_SERVICE,
+            client_sig=ACCESS_TOKEN_CLIENT_SIGNATURE,
+        )
+        self.assertEqual(expected_access_token, access_token)
+        self.assertEqual(m_log.call_count, 0)
+
+        # Reset mocks
+        m_perform_oauth.reset_mock()
+        m_log.reset_mock()
+
+        # Another request with non expired token must return the same token
+        # (no new requests)
+        access_token = self.client.get_access_token()
+        self.assertEqual(expected_access_token, access_token)
+        self.assertEqual(m_perform_oauth.call_count, 0)
+
+        # Another request with expired token must return new token (new request)
+        self.client.access_token_date = self.client.access_token_date - timedelta(
+            ACCESS_TOKEN_DURATION + 1
+        )
+        access_token = self.client.get_access_token()
+        self.assertEqual(m_perform_oauth.call_count, 1)
+
+    def test_get_homegraph(self):
+        pass
+
+    def test_google_devices(self):
+        pass
+
+    def test_google_devices_json(self):
+        pass

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -12,7 +12,7 @@ faker.add_provider(internet_provider)
 faker.add_provider(python_provider)
 
 
-class GLocalAuthenticationTokensClientTests(TestCase):
+class GoogleDeviceTests(TestCase):
     def setUp(self):
         """Setup method run before every test"""
         pass


### PR DESCRIPTION
Haven't really had time to finish it up with `homegraph` and `get_devices`, but added some client tests to make sure we fetch tokens right.
