### PR TITLE
Enable distributing type info with a package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Typing :: Typed",
 ]
 description = "Tool to extract Google device local authentication tokens in Python"
 keywords = [
@@ -15,6 +16,7 @@ keywords = [
     "Google",
     "LocalAuthenticationTokens",
 ]
+include = ["glocaltokens/py.typed"]
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/leikoilja/glocaltokens"


### PR DESCRIPTION
To make the package [PEP-561](https://www.python.org/dev/peps/pep-0561/) compliant this PR 
enables distributing typing info
 
Required by: https://github.com/leikoilja/ha-google-home/pull/88