### PR TITLE
Reduce discovery timeout

### DIFF
--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -15,6 +15,7 @@ from .const import (
     ACCESS_TOKEN_DURATION,
     ACCESS_TOKEN_SERVICE,
     ANDROID_ID_LENGTH,
+    DISCOVERY_TIMEOUT,
     GOOGLE_HOME_FOYER_API,
     HOMEGRAPH_DURATION,
     JSON_KEY_DEVICE_NAME,
@@ -336,6 +337,7 @@ class GLocalAuthenticationTokens:
         disable_discovery: bool = False,
         zeroconf_instance=None,
         force_homegraph_reload: bool = False,
+        discovery_timeout: int = DISCOVERY_TIMEOUT,
     ) -> List[Device]:
         """
         Returns a list of google devices with their local authentication tokens,
@@ -347,6 +349,7 @@ class GLocalAuthenticationTokens:
         zeroconf_instance: If you already have an initialized zeroconf instance,
           use it here.
         force_homegraph_reload: If the stored homegraph should be generated again.
+        discovery_timeout: Timeout for zeroconf discovery in seconds.
         """
 
         # Set models_list to empty list if None
@@ -365,6 +368,7 @@ class GLocalAuthenticationTokens:
             LOGGER.debug("Getting network devices...")
             network_devices = discover_devices(
                 models_list,
+                timeout=discovery_timeout,
                 zeroconf_instance=zeroconf_instance,
                 logging_level=self.logging_level,
             )

--- a/glocaltokens/const.py
+++ b/glocaltokens/const.py
@@ -14,7 +14,8 @@ GOOGLE_HOME_FOYER_API = "googlehomefoyer-pa.googleapis.com:443"
 
 HOMEGRAPH_DURATION = 24 * 60 * 60
 
-DISCOVER_TIMEOUT = 20
+DISCOVERY_TIMEOUT = 2
+
 GOOGLE_HOME_MODELS = [
     "Google Home",
     "Google Home Mini",

--- a/glocaltokens/scanner.py
+++ b/glocaltokens/scanner.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from zeroconf import ServiceListener
 
-from .const import DISCOVER_TIMEOUT
+from .const import DISCOVERY_TIMEOUT
 from .utils import network as net_utils, types as type_utils
 
 LOGGER = logging.getLogger(__name__)
@@ -126,7 +126,7 @@ class GoogleDevice:
 def discover_devices(
     models_list: Optional[List[str]] = None,
     max_devices: int = None,
-    timeout: int = DISCOVER_TIMEOUT,
+    timeout: int = DISCOVERY_TIMEOUT,
     zeroconf_instance=None,
     logging_level=logging.ERROR,
 ):
@@ -141,10 +141,10 @@ def discover_devices(
     def callback():
         """Called when zeroconf has discovered a new chromecast."""
         if max_devices is not None and listener.count >= max_devices:
-            discover_complete.set()
+            discovery_complete.set()
 
     LOGGER.debug("Creating new Event for discovery completion...")
-    discover_complete = Event()
+    discovery_complete = Event()
     LOGGER.debug("Creating new CastListener...")
     listener = CastListener(callback)
     if not zeroconf_instance:
@@ -158,7 +158,7 @@ def discover_devices(
 
     # Wait for the timeout or the maximum number of devices
     LOGGER.debug("Waiting for discovery completion...")
-    discover_complete.wait(timeout)
+    discovery_complete.wait(timeout)
 
     devices = []
     LOGGER.debug("Got %s devices. Iterating...", len(listener.devices))

--- a/poetry.lock
+++ b/poetry.lock
@@ -120,7 +120,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "decorator"
-version = "5.0.1"
+version = "5.0.6"
 description = "Decorators for Humans"
 category = "dev"
 optional = false
@@ -793,8 +793,8 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 decorator = [
-    {file = "decorator-5.0.1-py2.py3-none-any.whl", hash = "sha256:2ec6e8cce2d71850b0af58ceceeab83f4bbaf60e1cc23d96db08c9d1425b7ac0"},
-    {file = "decorator-5.0.1.tar.gz", hash = "sha256:1e53162e016f317a61d93848f00e80e7109ca9ed06846c7f2930cf0ebede7c6c"},
+    {file = "decorator-5.0.6-py3-none-any.whl", hash = "sha256:d9f2d2863183a3c0df05f4b786f2e6b8752c093b3547a558f287bf3022fd2bf4"},
+    {file = "decorator-5.0.6.tar.gz", hash = "sha256:f2e71efb39412bfd23d878e896a51b07744f2e2250b2e87d158e76828c5ae202"},
 ]
 distlib = [
     {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ ipdb = "^0.13.7"
 "Bug Tracker" = "https://github.com/leikoilja/glocaltokens/issues"
 "Release Notes" = "https://github.com/leikoilja/glocaltokens/releases"
 
+[tool.pylint.master]
+extension-pkg-whitelist = [
+    "_socket",
+]
+
 [tool.pylint.format]
 max-line-length = 88
 min-similarity-lines = 7


### PR DESCRIPTION
I noticed in my logs and logs of other people that zeroconf discovery is actually pretty fast and all devices are discovered under 1 second.

Reducing this timeout will make `google_home` initial setup and component startup much faster.

Also add an option to `get_google_devices` to override it.

For some reason `pylint` was broken because it was unable to find `socket` symbols which are implemented in C. Fixed that as well.

And `decorator==5.0.1` no longer exists: https://pypi.org/project/decorator/#history