### PR TITLE
Set Dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: pip
     directory: "/"
+    versioning-strategy: lockfile-only
     schedule:
       interval: daily
     labels:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,14 @@
 dependencies:
-  - poetry.lock
+  - all: ["poetry.lock", "!*.py"]
 
 documentation:
-  - "*.md"
+  - any: ["*.md"]
+    all: ["!*.py"]
 
 github structure:
-  - .github/*
+  - any: [".github/*"]
+    all: ["!*.py"]
 
 test:
-  - tests/*
+  - any: ["tests/*"]
+    all: ["!glocaltokens/*"]


### PR DESCRIPTION
As we discussed, set versioning stratagy to lockfile only to prevent changed in `pyproject.toml` and preserve library versioning constraints. This should prevent `grpcio` updates. Also as a library `glocaltokens` should have more relaxed versioning requirements.

Also import updated Labeler config from `ha-google-home`.