### PR TITLE
Cleanup depdendabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,7 @@ updates:
     versioning-strategy: lockfile-only
     schedule:
       interval: daily
-    labels:
-      - "dependencies"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    labels:
-      - "dependencies"


### PR DESCRIPTION
These are useless. `dependencies` is the default anyway.