### PR TITLE
Add type hints to tests, enable strict checks

### DIFF
--- a/glocaltokens/const.py
+++ b/glocaltokens/const.py
@@ -1,31 +1,32 @@
 """Globally used constants"""
+from typing import Final, List
 
-ACCESS_TOKEN_APP_NAME = "com.google.android.apps.chromecast.app"
-ACCESS_TOKEN_CLIENT_SIGNATURE = "24bb24c05e47e0aefa68a58a766179d9b613a600"
-ACCESS_TOKEN_DURATION = 60 * 60
-ACCESS_TOKEN_SERVICE = "oauth2:https://www.google.com/accounts/OAuthLogin"
+ACCESS_TOKEN_APP_NAME: Final[str] = "com.google.android.apps.chromecast.app"
+ACCESS_TOKEN_CLIENT_SIGNATURE: Final[str] = "24bb24c05e47e0aefa68a58a766179d9b613a600"
+ACCESS_TOKEN_DURATION: Final[int] = 60 * 60
+ACCESS_TOKEN_SERVICE: Final[str] = "oauth2:https://www.google.com/accounts/OAuthLogin"
 
-ANDROID_ID_LENGTH = 14
-MASTER_TOKEN_LENGTH = 216
-ACCESS_TOKEN_LENGTH = 315
-LOCAL_AUTH_TOKEN_LENGTH = 108
+ANDROID_ID_LENGTH: Final[int] = 14
+MASTER_TOKEN_LENGTH: Final[int] = 216
+ACCESS_TOKEN_LENGTH: Final[int] = 315
+LOCAL_AUTH_TOKEN_LENGTH: Final[int] = 108
 
-GOOGLE_HOME_FOYER_API = "googlehomefoyer-pa.googleapis.com:443"
+GOOGLE_HOME_FOYER_API: Final[str] = "googlehomefoyer-pa.googleapis.com:443"
 
-HOMEGRAPH_DURATION = 24 * 60 * 60
+HOMEGRAPH_DURATION: Final[int] = 24 * 60 * 60
 
-DISCOVERY_TIMEOUT = 2
+DISCOVERY_TIMEOUT: Final[int] = 2
 
-GOOGLE_HOME_MODELS = [
+GOOGLE_HOME_MODELS: Final[List[str]] = [
     "Google Home",
     "Google Home Mini",
     "Google Nest Mini",
     "Lenovo Smart Clock",
 ]
 
-JSON_KEY_DEVICE_NAME = "device_name"
-JSON_KEY_GOOGLE_DEVICE = "google_device"
-JSON_KEY_HARDWARE = "hardware"
-JSON_KEY_IP = "ip"
-JSON_KEY_LOCAL_AUTH_TOKEN = "local_auth_token"
-JSON_KEY_PORT = "port"
+JSON_KEY_DEVICE_NAME: Final[str] = "device_name"
+JSON_KEY_GOOGLE_DEVICE: Final[str] = "google_device"
+JSON_KEY_HARDWARE: Final[str] = "hardware"
+JSON_KEY_IP: Final[str] = "ip"
+JSON_KEY_LOCAL_AUTH_TOKEN: Final[str] = "local_auth_token"
+JSON_KEY_PORT: Final[str] = "port"

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,12 @@ ignore =
 
 [mypy]
 python_version = 3.8
-check_untyped_defs = True
-disallow_incomplete_defs = True
+strict = True
+disallow_any_explicit = True
+disallow_any_unimported = True
+show_none_errors = True
+warn_no_return = True
+warn_unreachable = True
 
 [mypy-faker]
 ignore_missing_imports = True

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -4,13 +4,19 @@ Common assertion helper classes used for unittesting
 # pylint: disable=invalid-name
 from unittest import TestCase
 
+from glocaltokens.client import Device
+from glocaltokens.google.internal.home.foyer.v1_pb2 import GetHomeGraphResponse
 import glocaltokens.utils.token as token_utils
 
 
 class DeviceAssertions(TestCase):
     """Device specific assessors"""
 
-    def assertDevice(self, homegraph_device, homegraph_device_struct):
+    def assertDevice(
+        self,
+        homegraph_device: Device,
+        homegraph_device_struct: GetHomeGraphResponse.Home.Device,
+    ) -> None:
         """
         Custom assertion because we create Device class object
         for each of received homegraph devices,
@@ -30,16 +36,9 @@ class DeviceAssertions(TestCase):
 class TypeAssertions(TestCase):
     """Type assessors"""
 
-    def assertIsString(self, variable):
-        """Assert the given variable is of string type"""
-        self.assertTrue(
-            isinstance(variable, str),
-            msg=f"Given variable {variable} is not String type",
-        )
-
-    def assertIsAasEt(self, variable):
+    def assertIsAasEt(self, variable: str) -> None:
         """Assert the given variable is a of string type and follows AAS token format"""
         self.assertTrue(
-            isinstance(variable, str) and token_utils.is_aas_et(variable),
+            token_utils.is_aas_et(variable),
             msg=f"Given variable {variable} doesn't follow the AAS_ET format",
         )

--- a/tests/factory/providers.py
+++ b/tests/factory/providers.py
@@ -10,20 +10,13 @@ from glocaltokens.const import (
     LOCAL_AUTH_TOKEN_LENGTH,
     MASTER_TOKEN_LENGTH,
 )
+from glocaltokens.google.internal.home.foyer.v1_pb2 import GetHomeGraphResponse
 from glocaltokens.utils.token import generate as generate_token
 
 fake = Faker()
 
 
-class Struct:
-    """Structure type"""
-
-    def __init__(self, **entries):
-        """Initialization"""
-        self.__dict__.update(entries)
-
-
-class UtilsProvider(BaseProvider):
+class UtilsProvider(BaseProvider):  # type: ignore
     """Utility provider"""
 
     def version(self) -> str:
@@ -31,7 +24,7 @@ class UtilsProvider(BaseProvider):
         return f"{fake.pyint()}.{fake.pyint()}.{fake.pyint()}"
 
 
-class TokenProvider(BaseProvider):
+class TokenProvider(BaseProvider):  # type: ignore
     """Token provider"""
 
     def master_token(self) -> str:
@@ -50,19 +43,17 @@ class TokenProvider(BaseProvider):
 class HomegraphProvider(TokenProvider):
     """Homegraph provider"""
 
-    def homegraph_device(self) -> Struct:
+    def homegraph_device(self) -> GetHomeGraphResponse.Home.Device:
         """Using the content from test requests as reference"""
-        return Struct(
-            **{
-                "local_auth_token": self.local_auth_token(),
-                "device_name": fake.word(),
-                "hardware": Struct(**{"model": fake.word()}),
-            }
+        return GetHomeGraphResponse.Home.Device(
+            local_auth_token=self.local_auth_token(),
+            device_name=fake.word(),
+            hardware=GetHomeGraphResponse.Home.Device.Hardware(model=fake.word()),
         )
 
     def homegraph_devices(
         self, min_devices: int = 1, max_devices: int = 10, count: Optional[int] = None
-    ) -> List[Struct]:
+    ) -> List[GetHomeGraphResponse.Home.Device]:
         """
         Generates a random amount of devices, in the range specified.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from faker import Faker
 from faker.providers import internet
-from mock import patch
+from mock import NonCallableMock, patch
 
 from glocaltokens.client import Device, GLocalAuthenticationTokens
 from glocaltokens.const import (
@@ -36,13 +36,13 @@ faker.add_provider(internet)
 class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, TestCase):
     """GLocalAuthenticationTokens clien specific unittests"""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Setup method run before every test"""
         self.client = GLocalAuthenticationTokens(
             username=faker.word(), password=faker.word()
         )
 
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         """Valid initialization tests"""
         username = faker.word()
         password = faker.word()
@@ -60,20 +60,16 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         self.assertEqual(master_token, client.master_token)
         self.assertEqual(android_id, client.android_id)
 
-        self.assertIsString(client.username)
-        self.assertIsString(client.password)
-        self.assertIsString(client.master_token)
-        self.assertIsString(client.android_id)
-
         self.assertIsNone(client.access_token)
         self.assertIsNone(client.homegraph)
         self.assertIsNone(client.access_token_date)
         self.assertIsNone(client.homegraph_date)
 
+        assert client.master_token is not None
         self.assertIsAasEt(client.master_token)
 
     @patch("glocaltokens.client.LOGGER.error")
-    def test_initialization__valid(self, m_log):
+    def test_initialization__valid(self, m_log: NonCallableMock) -> None:
         """Valid initialization tests"""
         # With username and password
         GLocalAuthenticationTokens(username=faker.word(), password=faker.word())
@@ -83,9 +79,11 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         GLocalAuthenticationTokens(master_token=faker.master_token())
         self.assertEqual(m_log.call_count, 0)
 
-    @patch("glocaltokens.client.LOGGER.setLevel")
     # pylint: disable=no-self-use
-    def test_initialization__valid_verbose_logger(self, m_set_level):
+    @patch("glocaltokens.client.LOGGER.setLevel")
+    def test_initialization__valid_verbose_logger(
+        self, m_set_level: NonCallableMock
+    ) -> None:
         """Valid initialization tests with verbose logging"""
         # Non verbose
         GLocalAuthenticationTokens(username=faker.word(), password=faker.word())
@@ -100,7 +98,7 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         m_set_level.assert_called_once_with(logging.DEBUG)
 
     @patch("glocaltokens.client.LOGGER.error")
-    def test_initialization__invalid(self, m_log):
+    def test_initialization__invalid(self, m_log: NonCallableMock) -> None:
         """Invalid initialization tests"""
         # Without username
         GLocalAuthenticationTokens(password=faker.word())
@@ -118,18 +116,16 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         GLocalAuthenticationTokens(master_token=faker.word())
         self.assertEqual(m_log.call_count, 4)
 
-    def test_get_android_id(self):
+    def test_get_android_id(self) -> None:
         """Test getting android id"""
         android_id = self.client.get_android_id()
         self.assertTrue(len(android_id) == ANDROID_ID_LENGTH)
-
-        self.assertIsString(android_id)
 
         # Make sure we get the same ID when called further
         self.assertEqual(android_id, self.client.get_android_id())
 
     # pylint: disable=protected-access
-    def test_generate_mac_string(self):
+    def test_generate_mac_string(self) -> None:
         """Test generating mac string"""
         mac_string = GLocalAuthenticationTokens._generate_mac_string()
         self.assertTrue(len(mac_string) == ANDROID_ID_LENGTH)
@@ -139,7 +135,7 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
             mac_string, GLocalAuthenticationTokens._generate_mac_string()
         )
 
-    def test_has_expired(self):
+    def test_has_expired(self) -> None:
         """Test expiry method"""
         duration_sec = 60
         now = datetime.now()
@@ -158,7 +154,9 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
 
     @patch("glocaltokens.client.LOGGER.error")
     @patch("glocaltokens.client.perform_master_login")
-    def test_get_master_token(self, m_perform_master_login, m_log):
+    def test_get_master_token(
+        self, m_perform_master_login: NonCallableMock, m_log: NonCallableMock
+    ) -> None:
         """Test getting master token"""
         # No token in response
         self.assertIsNone(self.client.get_master_token())
@@ -188,7 +186,12 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
     @patch("glocaltokens.client.LOGGER.error")
     @patch("glocaltokens.client.perform_master_login")
     @patch("glocaltokens.client.perform_oauth")
-    def test_get_access_token(self, m_perform_oauth, m_get_master_token, m_log):
+    def test_get_access_token(
+        self,
+        m_perform_oauth: NonCallableMock,
+        m_get_master_token: NonCallableMock,
+        m_log: NonCallableMock,
+    ) -> None:
         """Test getting access token"""
         master_token = faker.master_token()
         m_get_master_token.return_value = {"Token": master_token}
@@ -251,14 +254,14 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
     @patch("glocaltokens.client.GLocalAuthenticationTokens.get_access_token")
     def test_get_homegraph(
         self,
-        _m_get_access_token,
-        m_get_home_graph_request,
-        m_structure_service_stub,
-        m_secure_channel,
-        m_composite_channel_credentials,
-        m_access_token_call_credentials,
-        m_ssl_channel_credentials,
-    ):
+        _m_get_access_token: NonCallableMock,
+        m_get_home_graph_request: NonCallableMock,
+        m_structure_service_stub: NonCallableMock,
+        m_secure_channel: NonCallableMock,
+        m_composite_channel_credentials: NonCallableMock,
+        m_access_token_call_credentials: NonCallableMock,
+        m_ssl_channel_credentials: NonCallableMock,
+    ) -> None:
         """Test getting homegraph"""
         # New homegraph
         self.client.get_homegraph()
@@ -293,7 +296,7 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         self.assertEqual(m_get_home_graph_request.call_count, 2)
 
     @patch("glocaltokens.client.GLocalAuthenticationTokens.get_homegraph")
-    def test_get_google_devices(self, m_get_homegraph):
+    def test_get_google_devices(self, m_get_homegraph: NonCallableMock) -> None:
         """Test getting google devices"""
         # With just one device returned from homegraph
         homegraph_device = faker.homegraph_device()
@@ -304,7 +307,6 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         self.assertEqual(len(google_devices), 1)
 
         google_device = google_devices[0]
-        self.assertEqual(type(google_device), Device)
         self.assertDevice(google_device, homegraph_device)
 
         # With two devices returned from homegraph
@@ -325,7 +327,9 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         self.assertDevice(google_devices[0], homegraph_device_valid)
 
     @patch("glocaltokens.client.GLocalAuthenticationTokens.get_google_devices")
-    def test_get_google_devices_json(self, m_get_google_devices):
+    def test_get_google_devices_json(
+        self, m_get_google_devices: NonCallableMock
+    ) -> None:
         """Test getting google devices as JSON"""
         device_name = faker.word()
         local_auth_token = faker.local_auth_token()
@@ -343,7 +347,6 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
 
         json_string = self.client.get_google_devices_json(disable_discovery=True)
         self.assertEqual(m_get_google_devices.call_count, 1)
-        self.assertIsString(json_string)
         received_json = json.loads(json_string)
         received_device = received_json[0]
         self.assertEqual(received_device[JSON_KEY_DEVICE_NAME], device_name)
@@ -358,7 +361,7 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
 class DeviceClientTests(TypeAssertions, TestCase):
     """Device specific unittests"""
 
-    def test_initialization__valid(self):
+    def test_initialization__valid(self) -> None:
         """Test initialization that is valid"""
         local_auth_token = faker.local_auth_token()
 
@@ -373,7 +376,7 @@ class DeviceClientTests(TypeAssertions, TestCase):
         self.assertEqual(device.local_auth_token, local_auth_token)
 
     @patch("glocaltokens.client.LOGGER.error")
-    def test_initialization__invalid(self, m_log):
+    def test_initialization__invalid(self, m_log: NonCallableMock) -> None:
         """Test initialization that is invalid"""
         # With only ip
         device = Device(

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from faker import Faker
 from faker.providers import internet as internet_provider, python as python_provider
-from mock import patch
+from mock import NonCallableMock, patch
 
 from glocaltokens.scanner import GoogleDevice
 
@@ -17,7 +17,7 @@ class GoogleDeviceTests(TestCase):
     GoogleDevice specific tests
     """
 
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         """Initialization tests"""
         name = faker.word()
         ip_address = faker.ipv4_private()
@@ -35,7 +35,7 @@ class GoogleDeviceTests(TestCase):
         )
 
     @patch("glocaltokens.scanner.LOGGER.error")
-    def test_initialization__valid(self, mock):
+    def test_initialization__valid(self, mock: NonCallableMock) -> None:
         """Valid initialization tests"""
         GoogleDevice(
             faker.word(), faker.ipv4_private(), faker.port_number(), faker.word()
@@ -43,7 +43,7 @@ class GoogleDeviceTests(TestCase):
         self.assertEqual(mock.call_count, 0)
 
     @patch("glocaltokens.scanner.LOGGER.error")
-    def test_initialization__invalid(self, mock):
+    def test_initialization__invalid(self, mock: NonCallableMock) -> None:
         """Invalid initialization tests"""
         # With invalid IP
         GoogleDevice(faker.word(), faker.word(), faker.port_number(), faker.word())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ faker = Faker()
 class UtilsTests(TestCase):
     """Utilities tests"""
 
-    def test_censor(self):
+    def test_censor(self) -> None:
         """Testing sensitive info censoring"""
         # With word
         secret_string = faker.word()


### PR DESCRIPTION
Enforce the same strict checks as we do in `ha-google-home`.