### PR TITLE
Action to automatically publish new version on PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,4 +35,6 @@ jobs:
         run: poetry build
 
       - name: Publish to PyPI
-        run: POETRY_PYPI_TOKEN_PYPI="${{ secrets.PYPI_TOKEN }}" poetry publish
+        run: poetry publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    strategy:
+      matrix:
+        python-version: [3.8]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.1.0
+        with:
+          poetry-version: 1.1.5
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Set version
+        run: poetry version $(git describe --tags --abbrev=0 | sed -e "s/^v//")
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish to PyPI
+        run: POETRY_PYPI_TOKEN_PYPI="${{ secrets.PYPI_TOKEN }}" poetry publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,6 @@ jobs:
         run: poetry build
 
       - name: Publish to PyPI
-        run: poetry publish
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+          poetry publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "glocaltokens"
-version = "0.3.1"
+version = "0.0.0"
 authors = ["Ilja Leiko <leikoilja@gmail.com>"]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This action is supposed to automatically assign version based on git tag, build package and publish it on PyPI.

Haven't tested everything together, especially the last command.

Locally this will build version `0.0.0` but this should be fine because with this we only need to publish it with this action.

Poetry just merged support of plugins which will be released in v1.2. After that we can use this as a real plugin, right now it's not very simple to install: https://github.com/mtkennerly/poetry-dynamic-versioning

Closes #88 