### PR TITLE
Refactor scanner

### DIFF
--- a/glocaltokens/const.py
+++ b/glocaltokens/const.py
@@ -3,32 +3,32 @@ from __future__ import annotations
 
 from typing import Final
 
-ACCESS_TOKEN_APP_NAME: Final[str] = "com.google.android.apps.chromecast.app"
-ACCESS_TOKEN_CLIENT_SIGNATURE: Final[str] = "24bb24c05e47e0aefa68a58a766179d9b613a600"
-ACCESS_TOKEN_DURATION: Final[int] = 60 * 60
-ACCESS_TOKEN_SERVICE: Final[str] = "oauth2:https://www.google.com/accounts/OAuthLogin"
+ACCESS_TOKEN_APP_NAME: Final = "com.google.android.apps.chromecast.app"
+ACCESS_TOKEN_CLIENT_SIGNATURE: Final = "24bb24c05e47e0aefa68a58a766179d9b613a600"
+ACCESS_TOKEN_DURATION: Final = 60 * 60
+ACCESS_TOKEN_SERVICE: Final = "oauth2:https://www.google.com/accounts/OAuthLogin"
 
-ANDROID_ID_LENGTH: Final[int] = 16
-MASTER_TOKEN_LENGTH: Final[int] = 216
-ACCESS_TOKEN_LENGTH: Final[int] = 315
-LOCAL_AUTH_TOKEN_LENGTH: Final[int] = 108
+ANDROID_ID_LENGTH: Final = 16
+MASTER_TOKEN_LENGTH: Final = 216
+ACCESS_TOKEN_LENGTH: Final = 315
+LOCAL_AUTH_TOKEN_LENGTH: Final = 108
 
-GOOGLE_HOME_FOYER_API: Final[str] = "googlehomefoyer-pa.googleapis.com:443"
+GOOGLE_HOME_FOYER_API: Final = "googlehomefoyer-pa.googleapis.com:443"
 
-HOMEGRAPH_DURATION: Final[int] = 24 * 60 * 60
+HOMEGRAPH_DURATION: Final = 24 * 60 * 60
 
-DISCOVERY_TIMEOUT: Final[int] = 2
+DISCOVERY_TIMEOUT: Final = 2
 
-GOOGLE_HOME_MODELS: Final[list[str]] = [
+GOOGLE_HOME_MODELS: Final = [
     "Google Home",
     "Google Home Mini",
     "Google Nest Mini",
     "Lenovo Smart Clock",
 ]
 
-JSON_KEY_DEVICE_NAME: Final[str] = "device_name"
-JSON_KEY_GOOGLE_DEVICE: Final[str] = "google_device"
-JSON_KEY_HARDWARE: Final[str] = "hardware"
-JSON_KEY_IP: Final[str] = "ip"
-JSON_KEY_LOCAL_AUTH_TOKEN: Final[str] = "local_auth_token"
-JSON_KEY_PORT: Final[str] = "port"
+JSON_KEY_DEVICE_NAME: Final = "device_name"
+JSON_KEY_NETWORK_DEVICE: Final = "network_device"
+JSON_KEY_HARDWARE: Final = "hardware"
+JSON_KEY_IP: Final = "ip"
+JSON_KEY_LOCAL_AUTH_TOKEN: Final = "local_auth_token"
+JSON_KEY_PORT: Final = "port"

--- a/glocaltokens/types.py
+++ b/glocaltokens/types.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from typing import TypedDict
 
 
-class GoogleDeviceDict(TypedDict):
-    """Typed dict for google_device field of DeviceDict."""
+class NetworkDeviceDict(TypedDict):
+    """Typed dict for network_device field of DeviceDict."""
 
     ip: str | None
     port: int | None
@@ -17,5 +17,5 @@ class DeviceDict(TypedDict):
     device_id: str
     device_name: str
     hardware: str | None
-    google_device: GoogleDeviceDict
+    network_device: NetworkDeviceDict
     local_auth_token: str | None

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -7,16 +7,16 @@ from unittest.mock import NonCallableMock, patch
 from faker import Faker
 from faker.providers import internet as internet_provider, python as python_provider
 
-from glocaltokens.scanner import GoogleDevice
+from glocaltokens.scanner import NetworkDevice
 
 faker = Faker()  # type: ignore
 faker.add_provider(internet_provider)
 faker.add_provider(python_provider)
 
 
-class GoogleDeviceTests(TestCase):
+class NetworkDeviceTests(TestCase):
     """
-    GoogleDevice specific tests
+    NetworkDevice specific tests
     """
 
     def test_initialization(self) -> None:
@@ -25,46 +25,29 @@ class GoogleDeviceTests(TestCase):
         ip_address = faker.ipv4_private()
         port = faker.port_number()
         model = faker.word()
+        unique_id = faker.word()
 
-        device = GoogleDevice(name, ip_address, port, model)
+        device = NetworkDevice(name, ip_address, port, model, unique_id)
         self.assertEqual(name, device.name)
         self.assertEqual(ip_address, device.ip_address)
         self.assertEqual(port, device.port)
         self.assertEqual(model, device.model)
+        self.assertEqual(unique_id, device.unique_id)
 
         self.assertEqual(
-            f"{{name:{name},ip:{ip_address},port:{port},model:{model}}}", str(device)
+            f"NetworkDevice(name='{name}', ip_address='{ip_address}', "
+            f"port={port}, model='{model}', unique_id='{unique_id}')",
+            str(device),
         )
 
     @patch("glocaltokens.scanner.LOGGER.error")
     def test_initialization__valid(self, mock: NonCallableMock) -> None:
         """Valid initialization tests"""
-        GoogleDevice(
-            faker.word(), faker.ipv4_private(), faker.port_number(), faker.word()
+        NetworkDevice(
+            faker.word(),
+            faker.ipv4_private(),
+            faker.port_number(),
+            faker.word(),
+            faker.word(),
         )
         self.assertEqual(mock.call_count, 0)
-
-    @patch("glocaltokens.scanner.LOGGER.error")
-    def test_initialization__invalid(self, mock: NonCallableMock) -> None:
-        """Invalid initialization tests"""
-        # With invalid IP
-        GoogleDevice(faker.word(), faker.word(), faker.port_number(), faker.word())
-        self.assertEqual(mock.call_count, 1)
-
-        # With negative port
-        GoogleDevice(
-            faker.word(),
-            faker.ipv4_private(),
-            faker.pyint(min_value=-9999, max_value=-1),
-            faker.word(),
-        )
-        self.assertEqual(mock.call_count, 2)
-
-        # With greater port
-        GoogleDevice(
-            faker.word(),
-            faker.ipv4_private(),
-            faker.pyint(min_value=65535, max_value=999999),
-            faker.word(),
-        )
-        self.assertEqual(mock.call_count, 3)


### PR DESCRIPTION
## Breaking changes
- Rename `google_device` to `network_device`.
- Remove `ip_address` and `port` fields from `Device` constructor, they're only used in tests and add code complexity.
## Scanner changes
- Stop discovery after the timeout. Inspired by pychromecast. Otherwise it can modify list of discovered devices while it's being processed. Also it spams logs.
- Store devices in dict to filter duplicates. Before `update_service` was inserting copies in devices list.
- Handle remove `remove_service`.
## Other changes
- Replace `GoogleDevice` class with `NetworkDevice` named tuple. It should really just hold the data, all checks are moved outside.
- Remove unnecessary type hints from `Final`, they can be inferred automatically.
- Remove few tests which are no longer needed.
- Update some comments.

Tested locally on my HA instance.