### PR TITLE
Match devices by unique ID

### DIFF
--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -396,8 +396,13 @@ class GLocalAuthenticationTokens:
 
                 network_device = None
                 if network_devices:
-                    LOGGER.debug("Looking for '%s' in local network", item.device_name)
-                    network_device = find_device(item.device_info.agent_info.unique_id)
+                    unique_id = item.device_info.agent_info.unique_id
+                    LOGGER.debug(
+                        "Looking for '%s' (id=%s) in local network",
+                        item.device_name,
+                        unique_id,
+                    )
+                    network_device = find_device(unique_id)
 
                 device = Device(
                     device_id=item.device_info.device_id,

--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -377,9 +377,9 @@ class GLocalAuthenticationTokens:
                 logging_level=self.logging_level,
             )
 
-        def find_device(name: str) -> NetworkDevice | None:
+        def find_device(unique_id: str) -> NetworkDevice | None:
             for device in network_devices:
-                if device.name == name:
+                if device.unique_id == unique_id:
                     return device
             return None
 
@@ -397,11 +397,13 @@ class GLocalAuthenticationTokens:
                 network_device = None
                 if network_devices:
                     LOGGER.debug("Looking for '%s' in local network", item.device_name)
-                    network_device = find_device(item.device_name)
+                    network_device = find_device(item.device_info.agent_info.unique_id)
 
                 device = Device(
                     device_id=item.device_info.device_id,
-                    device_name=item.device_name,
+                    device_name=network_device.name
+                    if network_device is not None
+                    else item.device_name,
                     local_auth_token=item.local_auth_token,
                     network_device=network_device,
                     hardware=item.hardware.model,

--- a/glocaltokens/const.py
+++ b/glocaltokens/const.py
@@ -25,6 +25,7 @@ GOOGLE_HOME_MODELS: Final = [
     "Google Nest Mini",
     "Lenovo Smart Clock",
 ]
+GOOGLE_CAST_GROUP: Final = "Google Cast Group"
 
 JSON_KEY_DEVICE_NAME: Final = "device_name"
 JSON_KEY_NETWORK_DEVICE: Final = "network_device"

--- a/glocaltokens/scanner.py
+++ b/glocaltokens/scanner.py
@@ -7,7 +7,7 @@ from typing import Callable, NamedTuple
 
 from zeroconf import ServiceBrowser, ServiceInfo, ServiceListener, Zeroconf
 
-from .const import DISCOVERY_TIMEOUT
+from .const import DISCOVERY_TIMEOUT, GOOGLE_CAST_GROUP
 from .utils import network as net_utils
 
 LOGGER = logging.getLogger(__name__)
@@ -183,6 +183,9 @@ def discover_devices(
                 'Skip discovered device since model "%s" is not in models_list',
                 device.model,
             )
+            continue
+        if device.model == GOOGLE_CAST_GROUP:
+            LOGGER.debug("Skip discovered cast group: %s", device.name)
             continue
         LOGGER.debug("Add discovered device: %s", device)
         devices.append(device)


### PR DESCRIPTION
Finally use these new IDs.

## Problem
I have a speaker stereo pair which shows in the app (and in home graph) as a single virtual device with model `Google Cast Group`.

But when the main speaker in this pair is not reachable (due of https://github.com/leikoilja/ha-google-home/issues/202), it starts to appear as name of that speaker instead of name of the pair.

This leads to non consistent results from glocaltokens.

## Solution
Local auth tokens are actually per physical device, so glocaltokens should ignore any virtual groups and return only list of actual devices.

This unique id is the same for speaker pair device in home graph and actual device, so in both cases it'll be matched to corresponding network device. Use the name of that network device for consistency.