### PR TITLE
Add possibility of using an address list instead

### DIFF
--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -382,7 +382,7 @@ class GLocalAuthenticationTokens:
             # We need to disable flake8-use-fstring because of the brackets,
             # it causes a false positive.
             LOGGER.error(
-                "Invalid dictionary structure for discovery_address_dict "
+                "Invalid dictionary structure for addresses dictionary "
                 "argument. Correct structure is {'device_name': 'ipaddress'}"  # noqa
             )
             return devices

--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -372,7 +372,7 @@ class GLocalAuthenticationTokens:
         devices: list[Device] = []
 
         def is_dict_with_valid_ipv4_addresses(data: dict[str, str]) -> bool:
-            # Test if the data structure is correct and if each entry contains a
+            # Validate the data structure is correct and that each entry contains a
             # valid IPv4 address.
             return isinstance(data, dict) and all(
                 isinstance(x, str) and is_valid_ipv4_address(x) for x in data.values()

--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -336,7 +336,8 @@ class GLocalAuthenticationTokens:
     def get_google_devices(
         self,
         models_list: list[str] | None = None,
-        discovery_address_dict: dict[str, str] | None = None,
+        disable_discovery: bool = False,
+        addresses: dict[str, str] | None = None,
         zeroconf_instance: Zeroconf | None = None,
         force_homegraph_reload: bool = False,
         discovery_timeout: int = DISCOVERY_TIMEOUT,
@@ -346,7 +347,9 @@ class GLocalAuthenticationTokens:
         and IP and ports if set in models_list.
 
         models_list: The list of accepted model names.
-        discovery_address_dict: Dict of network devices from the local network
+        disable_discovery: Whether or not the device's IP and port should
+          be searched for in the network.
+        addresses: Dict of network devices from the local network
           ({"name": "ip_address"}). If set to `None` will try to automatically
           discover network devices. Disable discovery by setting to `{}`.
         zeroconf_instance: If you already have an initialized zeroconf instance,
@@ -375,10 +378,8 @@ class GLocalAuthenticationTokens:
                 isinstance(x, str) and is_valid_ipv4_address(x) for x in data.values()
             )
 
-        if discovery_address_dict and not is_dict_with_valid_ipv4_addresses(
-            discovery_address_dict
-        ):
-            # We need to disable flake8-use-fstring, because of the brackets,
+        if addresses and not is_dict_with_valid_ipv4_addresses(addresses):
+            # We need to disable flake8-use-fstring because of the brackets,
             # it causes a false positive.
             LOGGER.error(
                 "Invalid dictionary structure for discovery_address_dict "
@@ -391,7 +392,7 @@ class GLocalAuthenticationTokens:
             return devices
 
         network_devices: list[NetworkDevice] = []
-        if discovery_address_dict is None:
+        if disable_discovery is False:
             LOGGER.debug("Automatically discovering network devices...")
             network_devices = discover_devices(
                 models_list,
@@ -406,7 +407,7 @@ class GLocalAuthenticationTokens:
                     return device
             return None
 
-        address_dict = discovery_address_dict if discovery_address_dict else {}
+        address_dict = addresses if addresses else {}
 
         LOGGER.debug("Iterating in %d homegraph devices", len(homegraph.home.devices))
         for item in homegraph.home.devices:
@@ -468,7 +469,8 @@ class GLocalAuthenticationTokens:
         self,
         models_list: list[str] | None = None,
         indent: int = 2,
-        discovery_address_dict: dict[str, str] | None = None,
+        disable_discovery: bool = False,
+        addresses: dict[str, str] | None = None,
         zeroconf_instance: Zeroconf | None = None,
         force_homegraph_reload: bool = False,
     ) -> str:
@@ -478,7 +480,9 @@ class GLocalAuthenticationTokens:
 
         models_list: The list of accepted model names.
         indent: The indentation for the json formatting.
-        discovery_address_dict: Dict of network devices from the local network
+        disable_discovery: Whether or not the device's IP and port should
+          be searched for in the network.
+        addresses: Dict of network devices from the local network
           ({"name": "ip_address"}). If set to `None` will try to automatically
           discover network devices. Disable discovery by setting to `{}`.
         zeroconf_instance: If you already have an initialized zeroconf instance,
@@ -488,7 +492,8 @@ class GLocalAuthenticationTokens:
 
         google_devices = self.get_google_devices(
             models_list=models_list,
-            discovery_address_dict=discovery_address_dict,
+            disable_discovery=disable_discovery,
+            addresses=addresses,
             zeroconf_instance=zeroconf_instance,
             force_homegraph_reload=force_homegraph_reload,
         )

--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -16,6 +16,7 @@ from .const import (
     ACCESS_TOKEN_DURATION,
     ACCESS_TOKEN_SERVICE,
     ANDROID_ID_LENGTH,
+    DEFAULT_DISCOVERY_PORT,
     DISCOVERY_TIMEOUT,
     GOOGLE_HOME_FOYER_API,
     HOMEGRAPH_DURATION,
@@ -26,6 +27,7 @@ from .scanner import NetworkDevice, discover_devices
 from .types import DeviceDict
 from .utils import network as net_utils, token as token_utils
 from .utils.logs import censor
+from .utils.network import is_valid_ipv4_address
 
 logging.basicConfig(level=logging.ERROR)
 LOGGER = logging.getLogger(__name__)
@@ -334,7 +336,7 @@ class GLocalAuthenticationTokens:
     def get_google_devices(
         self,
         models_list: list[str] | None = None,
-        disable_discovery: bool = False,
+        discovery_address_dict: dict[str, str] | None = None,
         zeroconf_instance: Zeroconf | None = None,
         force_homegraph_reload: bool = False,
         discovery_timeout: int = DISCOVERY_TIMEOUT,
@@ -344,8 +346,9 @@ class GLocalAuthenticationTokens:
         and IP and ports if set in models_list.
 
         models_list: The list of accepted model names.
-        disable_discovery: Whether or not the device's IP and port should
-          be searched for in the network.
+        discovery_address_dict: Dict of network devices from the local network
+          ({"name": "ip_address"}). If set to `None` will try to automatically
+          discover network devices. Disable discovery by setting to `{}`.
         zeroconf_instance: If you already have an initialized zeroconf instance,
           use it here.
         force_homegraph_reload: If the stored homegraph should be generated again.
@@ -365,13 +368,31 @@ class GLocalAuthenticationTokens:
 
         devices: list[Device] = []
 
+        def is_dict_with_valid_ipv4_addresses(data: dict[str, str]) -> bool:
+            # Test if the data structure is correct and if each entry contains a
+            # valid IPv4 address.
+            return isinstance(data, dict) and all(
+                isinstance(x, str) and is_valid_ipv4_address(x) for x in data.values()
+            )
+
+        if discovery_address_dict and not is_dict_with_valid_ipv4_addresses(
+            discovery_address_dict
+        ):
+            # We need to disable flake8-use-fstring, because of the brackets,
+            # it causes a false positive.
+            LOGGER.error(
+                "Invalid dictionary structure for discovery_address_dict "
+                "argument. Correct structure is {'device_name': 'ipaddress'}"  # noqa
+            )
+            return devices
+
         if homegraph is None:
             LOGGER.debug("Failed to fetch homegraph")
             return devices
 
         network_devices: list[NetworkDevice] = []
-        if disable_discovery is False:
-            LOGGER.debug("Getting network devices...")
+        if discovery_address_dict is None:
+            LOGGER.debug("Automatically discovering network devices...")
             network_devices = discover_devices(
                 models_list,
                 timeout=discovery_timeout,
@@ -384,6 +405,8 @@ class GLocalAuthenticationTokens:
                 if device.unique_id == unique_id:
                     return device
             return None
+
+        address_dict = discovery_address_dict if discovery_address_dict else {}
 
         LOGGER.debug("Iterating in %d homegraph devices", len(homegraph.home.devices))
         for item in homegraph.home.devices:
@@ -405,6 +428,14 @@ class GLocalAuthenticationTokens:
                         unique_id,
                     )
                     network_device = find_device(unique_id)
+                elif item.device_name in address_dict:
+                    network_device = NetworkDevice(
+                        name=item.device_name,
+                        ip_address=address_dict[item.device_name],
+                        port=DEFAULT_DISCOVERY_PORT,
+                        model=item.hardware.model,
+                        unique_id=item.device_info.device_id,
+                    )
 
                 device = Device(
                     device_id=item.device_info.device_id,
@@ -437,7 +468,7 @@ class GLocalAuthenticationTokens:
         self,
         models_list: list[str] | None = None,
         indent: int = 2,
-        disable_discovery: bool = False,
+        discovery_address_dict: dict[str, str] | None = None,
         zeroconf_instance: Zeroconf | None = None,
         force_homegraph_reload: bool = False,
     ) -> str:
@@ -447,8 +478,9 @@ class GLocalAuthenticationTokens:
 
         models_list: The list of accepted model names.
         indent: The indentation for the json formatting.
-        disable_discovery: Whether or not the device's IP and port should
-          be searched for in the network.
+        discovery_address_dict: Dict of network devices from the local network
+          ({"name": "ip_address"}). If set to `None` will try to automatically
+          discover network devices. Disable discovery by setting to `{}`.
         zeroconf_instance: If you already have an initialized zeroconf instance,
           use it here.
         force_homegraph_reload: If the stored homegraph should be generated again.
@@ -456,7 +488,7 @@ class GLocalAuthenticationTokens:
 
         google_devices = self.get_google_devices(
             models_list=models_list,
-            disable_discovery=disable_discovery,
+            discovery_address_dict=discovery_address_dict,
             zeroconf_instance=zeroconf_instance,
             force_homegraph_reload=force_homegraph_reload,
         )

--- a/glocaltokens/const.py
+++ b/glocaltokens/const.py
@@ -18,6 +18,7 @@ GOOGLE_HOME_FOYER_API: Final = "googlehomefoyer-pa.googleapis.com:443"
 HOMEGRAPH_DURATION: Final = 24 * 60 * 60
 
 DISCOVERY_TIMEOUT: Final = 2
+DEFAULT_DISCOVERY_PORT: Final = 0
 
 GOOGLE_HOME_MODELS: Final = [
     "Google Home",

--- a/glocaltokens/scanner.py
+++ b/glocaltokens/scanner.py
@@ -47,12 +47,12 @@ class CastListener(ServiceListener):
         return len(self.devices)
 
     def add_service(self, zc: Zeroconf, type_: str, name: str) -> None:
-        """Add a service to the collection."""
+        """ Add a service to the collection. """
         LOGGER.debug("add_service %s, %s", type_, name)
         self._add_update_service(zc, type_, name, self.add_callback)
 
     def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
-        """Update a service in the collection."""
+        """ Update a service in the collection. """
         LOGGER.debug("update_service %s, %s", type_, name)
         self._add_update_service(zc, type_, name, self.update_callback)
 
@@ -71,7 +71,7 @@ class CastListener(ServiceListener):
         name: str,
         callback: Callable[[], None] | None,
     ) -> None:
-        """Add or update a service."""
+        """ Add or update a service. """
         if name.endswith("_sub._googlecast._tcp.local."):
             LOGGER.debug("_add_update_service ignoring %s, %s", type_, name)
             return

--- a/glocaltokens/scanner.py
+++ b/glocaltokens/scanner.py
@@ -47,12 +47,12 @@ class CastListener(ServiceListener):
         return len(self.devices)
 
     def add_service(self, zc: Zeroconf, type_: str, name: str) -> None:
-        """ Add a service to the collection. """
+        """Add a service to the collection."""
         LOGGER.debug("add_service %s, %s", type_, name)
         self._add_update_service(zc, type_, name, self.add_callback)
 
     def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
-        """ Update a service in the collection. """
+        """Update a service in the collection."""
         LOGGER.debug("update_service %s, %s", type_, name)
         self._add_update_service(zc, type_, name, self.update_callback)
 
@@ -71,7 +71,7 @@ class CastListener(ServiceListener):
         name: str,
         callback: Callable[[], None] | None,
     ) -> None:
-        """ Add or update a service. """
+        """Add or update a service."""
         if name.endswith("_sub._googlecast._tcp.local."):
             LOGGER.debug("_add_update_service ignoring %s, %s", type_, name)
             return

--- a/tests/factory/providers.py
+++ b/tests/factory/providers.py
@@ -43,14 +43,18 @@ class TokenProvider(BaseProvider):
 class HomegraphProvider(TokenProvider):
     """Homegraph provider"""
 
-    def homegraph_device(self) -> GetHomeGraphResponse.Home.Device:
+    def homegraph_device(
+        self, device_name: str | None = None
+    ) -> GetHomeGraphResponse.Home.Device:
         """Using the content from test requests as reference"""
+        device_name = device_name if device_name else faker.word()
+
         return GetHomeGraphResponse.Home.Device(
             local_auth_token=self.local_auth_token(),
             device_info=GetHomeGraphResponse.Home.Device.DeviceInfo(
                 device_id=str(faker.uuid4)
             ),
-            device_name=faker.word(),
+            device_name=device_name,
             hardware=GetHomeGraphResponse.Home.Device.Hardware(model=faker.word()),
         )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -329,7 +329,8 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
 
         # With no discover_devices, with no model_list
         google_devices = self.client.get_google_devices(
-            discovery_address_dict={fake_device_name: fake_ip_address}
+            disable_discovery=True,
+            addresses={fake_device_name: fake_ip_address},
         )
         self.assertEqual(len(google_devices), 1)
 
@@ -353,7 +354,8 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
             homegraph_device_valid,
         ]
         google_devices = self.client.get_google_devices(
-            discovery_address_dict={fake_device_name: fake_ip_address}
+            disable_discovery=True,
+            addresses={fake_device_name: fake_ip_address},
         )
         self.assertEqual(len(google_devices), 1)
         self.assertDevice(google_devices[0], homegraph_device_valid)
@@ -386,7 +388,7 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
         )
         m_get_google_devices.return_value = [google_device]
 
-        json_string = self.client.get_google_devices_json(discovery_address_dict={})
+        json_string = self.client.get_google_devices_json(disable_discovery=True)
         self.assertEqual(m_get_google_devices.call_count, 1)
         received_json = json.loads(json_string)
         received_device = received_json[0]


### PR DESCRIPTION
This changes `disable_discovery` from a bool to `address_list` containing a dict. Example dict: ``{"Living room": "192.168.0.69"}` Not setting the address_list results in discovery been enabled. Setting it to and empty dict results in discovery being disabled.

I was not 100% sure on how to best implement this, so please provide feedback if something can be done better. 😄 

Code is tested, but can someone double check to make sure that we are not breaking anything with this.