### PR TITLE
Bump gpsoauth to v1.0.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -287,7 +287,7 @@ test = ["coverage (>=4.0.0,<5.0.0)", "pytest (>=4)", "pytest-cov (>=2)", "flake8
 
 [[package]]
 name = "gpsoauth"
-version = "1.0.0"
+version = "1.0.1"
 description = "A python client library for Google Play Services OAuth."
 category = "main"
 optional = false
@@ -928,7 +928,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e95aac6887dd1edcff1ad11f18abd15c367150c5a0a641c89e5b9883ebe26728"
+content-hash = "2e00364e989b3323cc3529c1606267308a7b7495b5af48aaa4bdef8437bd1fc1"
 
 [metadata.files]
 appdirs = [
@@ -1034,8 +1034,8 @@ flake8-use-fstring = [
     {file = "flake8-use-fstring-1.3.tar.gz", hash = "sha256:1bd4a409adbb93e64e711fdd26b88759c33792e3899f174edc68ddf7307e81b6"},
 ]
 gpsoauth = [
-    {file = "gpsoauth-1.0.0-py3-none-any.whl", hash = "sha256:149c374863eec17cdac5279d57e4905592a9cd74cc34b7e58671cb19f9238f39"},
-    {file = "gpsoauth-1.0.0.tar.gz", hash = "sha256:1c4d6a980625b8ab6f6f1cf3e30d9b10a6c61ababb2b60bfe4870649e9c82be0"},
+    {file = "gpsoauth-1.0.1-py3-none-any.whl", hash = "sha256:f02342581773602219dce0b577a5e9ebc9fa4ad30b6e7e67e085ca3f043e5adb"},
+    {file = "gpsoauth-1.0.1.tar.gz", hash = "sha256:c312f2beb3704f74101c62c2c5a2057511bb389a4408ca729c4fa58001ad164d"},
 ]
 grpc-stubs = [
     {file = "grpc-stubs-1.24.10.tar.gz", hash = "sha256:92460dbabea0e77e34241afe7594b86f5cef2f9ae6ca0230f1ae2430427c20f9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ homepage = "https://github.com/leikoilja/glocaltokens"
 repository = "https://github.com/leikoilja/glocaltokens"
 
 [tool.poetry.dependencies]
-gpsoauth = "^1.0.0"
+gpsoauth = "^1.0.1"
 python = "^3.8"
 simplejson = "^3.17.2"
 


### PR DESCRIPTION
Bumping gpsoauth version to the latest, fixing the outstanding issue we have #245 .

Closes #245 

Testes locally to work just fine :) 
Let's merge it in and release `glocaltokens` new minor version