### PR TITLE
Automatically strip +tag part from username

### DIFF
--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -206,6 +206,15 @@ class GLocalAuthenticationTokens:
         """Checks if an specified token/object has expired"""
         return datetime.now().timestamp() - creation_dt.timestamp() > duration
 
+    @staticmethod
+    def _filter_username(username: str) -> str:
+        """Remove `+tag` part from login."""
+        plus_pos = username.find("+")
+        if plus_pos != -1:
+            at_pos = username.find("@")
+            return username[:plus_pos] + (username[at_pos:] if at_pos != -1 else "")
+        return username
+
     def get_master_token(self) -> str | None:
         """Get google master token from username and password"""
         if self.username is None or self.password is None:
@@ -220,7 +229,9 @@ class GLocalAuthenticationTokens:
             res = {}
             try:
                 res = perform_master_login(
-                    self.username, self.password, self.get_android_id()
+                    self._filter_username(self.username),
+                    self.password,
+                    self.get_android_id(),
                 )
             except ValueError:
                 LOGGER.error(
@@ -254,7 +265,7 @@ class GLocalAuthenticationTokens:
                 LOGGER.error("Username is not set.")
                 return None
             res = perform_oauth(
-                self.username,
+                self._filter_username(self.username),
                 master_token,
                 self.get_android_id(),
                 app=ACCESS_TOKEN_APP_NAME,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -410,6 +410,17 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
             received_device[JSON_KEY_NETWORK_DEVICE][JSON_KEY_IP], ip_address
         )
 
+    def test_username_filtering(self) -> None:
+        """Test that +tag part is removed."""
+        self.assertEqual(
+            self.client._filter_username("login@domain.com"), "login@domain.com"
+        )
+        self.assertEqual(
+            self.client._filter_username("login+tag@domain.com"), "login@domain.com"
+        )
+        self.assertEqual(self.client._filter_username("login"), "login")
+        self.assertEqual(self.client._filter_username("login+tag"), "login")
+
 
 class DeviceClientTests(TypeAssertions, TestCase):
     """Device specific unittests"""


### PR DESCRIPTION
Added tests and tried on my account.

Also tested that dots in the username don't affect the login process and therefore can be left as is (you can add them in email address, e.g. `a.b@gmail.com` equals `ab@gmail.com`). 

Closes #260 