### PR TITLE
Escape plus sign in the username

### DIFF
--- a/glocaltokens/client.py
+++ b/glocaltokens/client.py
@@ -206,6 +206,11 @@ class GLocalAuthenticationTokens:
         """Checks if an specified token/object has expired"""
         return datetime.now().timestamp() - creation_dt.timestamp() > duration
 
+    @staticmethod
+    def _escape_username(username: str) -> str:
+        """Escape plus sign for some exotic accounts"""
+        return username.replace("+", "%2B")
+
     def get_master_token(self) -> str | None:
         """Get google master token from username and password"""
         if self.username is None or self.password is None:
@@ -220,7 +225,9 @@ class GLocalAuthenticationTokens:
             res = {}
             try:
                 res = perform_master_login(
-                    self.username, self.password, self.get_android_id()
+                    self._escape_username(self.username),
+                    self.password,
+                    self.get_android_id(),
                 )
             except ValueError:
                 LOGGER.error(
@@ -254,7 +261,7 @@ class GLocalAuthenticationTokens:
                 LOGGER.error("Username is not set.")
                 return None
             res = perform_oauth(
-                self.username,
+                self._escape_username(self.username),
                 master_token,
                 self.get_android_id(),
                 app=ACCESS_TOKEN_APP_NAME,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -410,6 +410,19 @@ class GLocalAuthenticationTokensClientTests(DeviceAssertions, TypeAssertions, Te
             received_device[JSON_KEY_NETWORK_DEVICE][JSON_KEY_IP], ip_address
         )
 
+    def test_username_escaping(self) -> None:
+        """Test that plus sign is escaped."""
+        self.assertEqual(
+            self.client._escape_username("login@domain.com"), "login@domain.com"
+        )
+        self.assertEqual(
+            self.client._escape_username("login+tag@domain.com"),
+            "login%2Btag@domain.com",
+        )
+        self.assertEqual(self.client._escape_username("login"), "login")
+        # Such account should be impossible to create.
+        self.assertEqual(self.client._escape_username("login+tag"), "login%2Btag")
+
 
 class DeviceClientTests(TypeAssertions, TestCase):
     """Device specific unittests"""


### PR DESCRIPTION
Apparently I was able to create Google account (not email) which has `+` in the username. And to get master token for it, `+` should be replaced with `%2B`.

Fixes #260 