### PR TITLE
Restore previous version of generated proto file

### DIFF
--- a/glocaltokens/google/internal/home/foyer/v1_pb2.py
+++ b/glocaltokens/google/internal/home/foyer/v1_pb2.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from google.protobuf import (
     descriptor as _descriptor,
-    descriptor_pool as _descriptor_pool,
     message as _message,
     reflection as _reflection,
     symbol_database as _symbol_database,
@@ -16,222 +15,5536 @@ from google.protobuf import (
 _sym_db = _symbol_database.Default()
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n#google/internal/home/foyer/v1.proto\x12\x1dgoogle.internal.home.foyer.v1"\x1d\n\x1bGetAssistantRoutinesRequest"\xf4\x06\n\x1cGetAssistantRoutinesResponse\x12M\n\x02p1\x18\x01 \x03(\x0b\x32\x41.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1\x12M\n\x02p2\x18\x02 \x01(\x0b\x32\x41.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part2\x1a\x8a\x05\n\x05Part1\x12\x14\n\x0croutine_name\x18\x01 \x01(\t\x12\\\n\x08workflow\x18\x03 \x01(\x0b\x32J.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow\x12\x0f\n\x07string4\x18\x04 \x01(\t\x12\x0f\n\x07string5\x18\x05 \x01(\t\x1a\xea\x03\n\x08WorkFlow\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x61\n\x05wf_s1\x18\x02 \x01(\x0b\x32R.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1\x1a\xec\x02\n\x07WF_Sub1\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12q\n\x08wf_s1_s1\x18\x02 \x01(\x0b\x32_.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1\x1a\xdc\x01\n\x0cWF_Sub1_Sub1\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12x\n\x07routine\x18\x02 \x01(\x0b\x32g.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.Routine\x1a\x41\n\x07Routine\x12\x12\n\nroutine_id\x18\x01 \x01(\t\x12\x0c\n\x04num2\x18\x02 \x01(\r\x12\x14\n\x0croutine_name\x18\x03 \x01(\t\x1a)\n\x05Part2\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x0f\n\x07string3\x18\x03 \x01(\t"4\n\x13GetHomeGraphRequest\x12\x0f\n\x07string1\x18\x03 \x01(\t\x12\x0c\n\x04num2\x18\x04 \x01(\t"\xbc\x37\n\x14GetHomeGraphResponse\x12\x12\n\ntimestamp1\x18\x01 \x01(\x04\x12\x46\n\x04home\x18\x02 \x01(\x0b\x32\x38.google.internal.home.foyer.v1.GetHomeGraphResponse.Home\x12I\n\x06groups\x18\x03 \x03(\x0b\x32\x39.google.internal.home.foyer.v1.GetHomeGraphResponse.Group\x12P\n\nroom_types\x18\x04 \x03(\x0b\x32<.google.internal.home.foyer.v1.GetHomeGraphResponse.RoomType\x12\x0f\n\x07string5\x18\x05 \x01(\t\x12\r\n\x05\x62ool6\x18\x06 \x01(\x08\x12T\n\x0c\x64\x65vice_types\x18\x07 \x03(\x0b\x32>.google.internal.home.foyer.v1.GetHomeGraphResponse.DeviceType\x12V\n\rproject_types\x18\t \x03(\x0b\x32?.google.internal.home.foyer.v1.GetHomeGraphResponse.ProjectType\x12P\n\tmessage11\x18\x0b \x03(\x0b\x32=.google.internal.home.foyer.v1.GetHomeGraphResponse.Message11\x12R\n\x0blinked_apps\x18\x0c \x03(\x0b\x32=.google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp\x1a\xc6\'\n\x04Home\x12\x0f\n\x07home_id\x18\x01 \x01(\t\x12\x11\n\thome_name\x18\x02 \x01(\t\x12S\n\x08location\x18\x03 \x01(\x0b\x32\x41.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location\x12Y\n\x0clinked_users\x18\x04 \x03(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.LinkedUser\x12L\n\x05rooms\x18\x06 \x03(\x0b\x32=.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room\x12P\n\x07\x64\x65vices\x18\x07 \x03(\x0b\x32?.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device\x12U\n\tmessage11\x18\x0b \x01(\x0b\x32\x42.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message11\x12\x10\n\x08string12\x18\x0c \x01(\t\x12U\n\tmessage13\x18\r \x01(\x0b\x32\x42.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13\x12\x11\n\tmessage14\x18\x0e \x01(\t\x12U\n\tmessage15\x18\x0f \x01(\x0b\x32\x42.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15\x1a\xd9\x01\n\x08Location\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x62\n\x0b\x63oordinates\x18\x02 \x01(\x0b\x32M.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.Coordinates\x12\x12\n\ntimestamp5\x18\x05 \x01(\x04\x12\x10\n\x08timezone\x18\x06 \x01(\t\x1a\x32\n\x0b\x43oordinates\x12\x10\n\x08latitude\x18\x01 \x01(\x01\x12\x11\n\tlongitude\x18\x02 \x01(\x01\x1a#\n\nLinkedUser\x12\x15\n\remail_address\x18\x01 \x01(\t\x1a\x9e\x01\n\x04Room\x12\x0f\n\x07room_id\x18\x01 \x01(\t\x12\x11\n\troom_name\x18\x03 \x01(\t\x12X\n\x08\x63\x61tegory\x18\x04 \x01(\x0b\x32\x46.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room.Category\x1a\x18\n\x08\x43\x61tegory\x12\x0c\n\x04name\x18\x01 \x01(\t\x1a\xbb\x18\n\x06\x44\x65vice\x12_\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32J.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo\x12\x13\n\x0b\x64\x65vice_name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x06 \x01(\t\x12\x0e\n\x06traits\x18\x07 \x03(\t\x12\x0e\n\x06suffix\x18\n \x01(\t\x12\\\n\tmessage12\x18\x0c \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12\x12\\\n\tmessage15\x18\x0f \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message15\x12Z\n\x08hardware\x18\x11 \x01(\x0b\x32H.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Hardware\x12\\\n\tmessage18\x18\x12 \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message18\x12\x13\n\x0btimestamp19\x18\x13 \x01(\x04\x12\\\n\tmessage20\x18\x14 \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20\x12\\\n\tmessage25\x18\x19 \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message25\x12`\n\x0clinked_users\x18\x1a \x03(\x0b\x32J.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.LinkedUser\x12\x18\n\x10local_auth_token\x18\x1c \x01(\t\x12U\n\x06states\x18\x1d \x03(\x0b\x32\x45.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.State\x12\\\n\tmessage30\x18\x1e \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30\x12\\\n\tmessage34\x18" \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message34\x12\r\n\x05num37\x18% \x01(\r\x12\x10\n\x08string41\x18) \x01(\t\x12\x10\n\x08string42\x18* \x01(\t\x1a\xc1\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12h\n\nagent_info\x18\x02 \x01(\x0b\x32T.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1aq\n\tMessage12\x12\x0c\n\x04num2\x18\x02 \x01(\r\x12\x0c\n\x04num4\x18\x04 \x01(\r\x12\x0c\n\x04num5\x18\x05 \x01(\r\x12\r\n\x05num37\x18% \x01(\r\x12\r\n\x05num38\x18& \x01(\r\x12\r\n\x05num45\x18- \x01(\r\x12\r\n\x05num46\x18. \x01(\r\x1a\x43\n\tMessage15\x12\x0c\n\x04num1\x18\x01 \x01(\x04\x12\x0c\n\x04num5\x18\x05 \x01(\x04\x12\x0c\n\x04num6\x18\x06 \x01(\x04\x12\x0c\n\x04num7\x18\x07 \x01(\x04\x1a\x19\n\x08Hardware\x12\r\n\x05model\x18\x02 \x01(\t\x1a \n\tMessage18\x12\x13\n\x0b\x64\x65vice_name\x18\x02 \x01(\t\x1a\x88\x08\n\tMessage20\x12\x64\n\x08message1\x18\x01 \x03(\x0b\x32R.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1\x1a\x94\x07\n\x08Message1\x12\x0b\n\x03key\x18\x01 \x01(\t\x12g\n\x05value\x18\x02 \x01(\x0b\x32X.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value\x1a\x91\x06\n\x05Value\x12s\n\x08message6\x18\x06 \x01(\x0b\x32\x61.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6\x1a\x92\x05\n\x08Message6\x12|\n\x08message1\x18\x01 \x01(\x0b\x32j.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1\x1a\x87\x04\n\x08Message1\x12\x85\x01\n\x08message5\x18\x05 \x01(\x0b\x32s.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5\x1a\xf2\x02\n\x08Message5\x12\x8e\x01\n\x08message1\x18\x01 \x03(\x0b\x32|.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1\x1a\xd4\x01\n\x08Message1\x12\x12\n\ncapability\x18\x01 \x01(\t\x12\x98\x01\n\x08message2\x18\x02 \x01(\x0b\x32\x85\x01.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1.Message2\x1a\x19\n\x08Message2\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x1a)\n\tMessage25\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x12\r\n\x05\x62ool2\x18\x02 \x01(\x08\x1a#\n\nLinkedUser\x12\x15\n\remail_address\x18\x01 \x01(\t\x1a$\n\x05State\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c\x1a\xa6\x02\n\tMessage30\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x64\n\x08message2\x18\x02 \x01(\x0b\x32R.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2\x1a\xa5\x01\n\x08Message2\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12m\n\x08message2\x18\x02 \x01(\x0b\x32[.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2.Message2\x1a\x19\n\x08Message2\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x1a\x1a\n\tMessage34\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x1a\x1a\n\tMessage11\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x1a\xe4\x03\n\tMessage13\x12]\n\x08message1\x18\x01 \x01(\x0b\x32K.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1\x12\x14\n\x0c\x64uo_call_url\x18\x02 \x01(\t\x12\x18\n\x10\x64uo_phone_number\x18\x03 \x01(\t\x1a\xc7\x02\n\x08Message1\x12k\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32V.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo\x1a\xcd\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12t\n\nagent_info\x18\x02 \x01(\x0b\x32`.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1a\xbc\x02\n\tMessage15\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x12\x0f\n\x07string2\x18\x02 \x01(\t\x12]\n\x08message3\x18\x03 \x03(\x0b\x32K.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x1a\xa0\x01\n\x08Message3\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x66\n\x08message2\x18\x02 \x01(\x0b\x32T.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3.Message2\x1a\x1b\n\x08Message2\x12\x0f\n\x07string1\x18\x01 \x01(\t\x1a\x87\x08\n\x05Group\x12Y\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32\x44.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo\x12\x12\n\ngroup_nmae\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x06 \x01(\t\x12\x0e\n\x06traits\x18\x07 \x01(\t\x12\x0e\n\x06suffix\x18\n \x01(\t\x12V\n\tmessage12\x18\x0c \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message12\x12V\n\tmessage15\x18\x0f \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message15\x12V\n\tmessage17\x18\x11 \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message17\x12V\n\tmessage18\x18\x12 \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message18\x12\x13\n\x0btimestamp19\x18\x13 \x01(\x04\x12V\n\tmessage34\x18" \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message34\x1a\xa8\x01\n\nDeviceInfo\x12\x62\n\nagent_info\x18\x02 \x01(\x0b\x32N.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1aI\n\tMessage12\x12\r\n\x05\x62ool3\x18\x03 \x01(\x08\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x12\x0e\n\x06\x62ool37\x18% \x01(\x08\x12\x0e\n\x06\x62ool38\x18& \x01(\x08\x1a\x38\n\tMessage15\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x0c\n\x04num5\x18\x05 \x01(\x04\x12\x0c\n\x04num6\x18\x06 \x01(\r\x1a \n\tMessage17\x12\x13\n\x0bgroup_model\x18\x02 \x01(\t\x1a\x1f\n\tMessage18\x12\x12\n\ngroup_name\x18\x02 \x01(\t\x1a\x1a\n\tMessage34\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x1a&\n\x08RoomType\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a(\n\nDeviceType\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a)\n\x0bProjectType\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a\x8d\x01\n\tMessage11\x12\x0c\n\x04name\x18\x01 \x01(\t\x12X\n\x08message2\x18\x02 \x01(\x0b\x32\x46.google.internal.home.foyer.v1.GetHomeGraphResponse.Message11.Message2\x1a\x18\n\x08Message2\x12\x0c\n\x04num2\x18\x02 \x01(\r\x1aW\n\tLinkedApp\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x0f\n\x07string2\x18\x02 \x01(\t\x12\x0c\n\x04num3\x18\x03 \x01(\r\x12\x0c\n\x04num4\x18\x04 \x01(\r\x12\x0c\n\x04num5\x18\x05 \x01(\r"\xdb\x02\n!GetAssistantDeviceSettingsRequest\x12`\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32K.google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo\x12\x0f\n\x07string2\x18\x02 \x01(\t\x1a\xc2\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12i\n\nagent_info\x18\x02 \x01(\x0b\x32U.google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t"\xe6\x01\n"GetAssistantDeviceSettingsResponse\x12\\\n\x08message1\x18\x01 \x01(\x0b\x32J.google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1\x1a\x62\n\x08Message1\x12\x0c\n\x04num1\x18\x01 \x01(\r\x12\x0c\n\x04num2\x18\x02 \x01(\r\x12\x0c\n\x04num4\x18\x04 \x01(\r\x12\x0c\n\x04num5\x18\x05 \x01(\r\x12\x0c\n\x04num6\x18\x06 \x01(\r\x12\x10\n\x08string10\x18\n \x01(\t"\xa3\x05\n$UpdateAssistantDeviceSettingsRequest\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x63\n\x0b\x64\x65vice_info\x18\x02 \x01(\x0b\x32N.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo\x12\x63\n\x0bupdate_data\x18\x03 \x01(\x0b\x32N.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData\x1a\xc5\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12l\n\nagent_info\x18\x02 \x01(\x0b\x32X.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1a\xd7\x01\n\nUpdateData\x12i\n\x08message1\x18\x01 \x01(\x0b\x32W.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData.Message1\x1a^\n\x08Message1\x12\x1f\n\x17youtube_restricted_mode\x18\x04 \x01(\r\x12!\n\x19youtube_tv_content_filter\x18\x05 \x01(\r\x12\x0e\n\x06locale\x18\n \x01(\t"8\n%UpdateAssistantDeviceSettingsResponse\x12\x0f\n\x07string1\x18\x01 \x01(\t2\xa8\x01\n\x12HomeControlService\x12\x91\x01\n\x14GetAssistantRoutines\x12:.google.internal.home.foyer.v1.GetAssistantRoutinesRequest\x1a;.google.internal.home.foyer.v1.GetAssistantRoutinesResponse0\x01\x32\x8c\x01\n\x11StructuresService\x12w\n\x0cGetHomeGraph\x12\x32.google.internal.home.foyer.v1.GetHomeGraphRequest\x1a\x33.google.internal.home.foyer.v1.GetHomeGraphResponse2\xe9\x02\n\x12HomeDevicesService\x12\xa3\x01\n\x1aGetAssistantDeviceSettings\x12@.google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest\x1a\x41.google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse0\x01\x12\xac\x01\n\x1dUpdateAssistantDeviceSettings\x12\x43.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest\x1a\x44.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsResponse0\x01\x62\x06proto3'
+DESCRIPTOR = _descriptor.FileDescriptor(
+    name="google/internal/home/foyer/v1.proto",
+    package="google.internal.home.foyer.v1",
+    syntax="proto3",
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+    serialized_pb=b'\n#google/internal/home/foyer/v1.proto\x12\x1dgoogle.internal.home.foyer.v1"\x1d\n\x1bGetAssistantRoutinesRequest"\xf4\x06\n\x1cGetAssistantRoutinesResponse\x12M\n\x02p1\x18\x01 \x03(\x0b\x32\x41.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1\x12M\n\x02p2\x18\x02 \x01(\x0b\x32\x41.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part2\x1a\x8a\x05\n\x05Part1\x12\x14\n\x0croutine_name\x18\x01 \x01(\t\x12\\\n\x08workflow\x18\x03 \x01(\x0b\x32J.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow\x12\x0f\n\x07string4\x18\x04 \x01(\t\x12\x0f\n\x07string5\x18\x05 \x01(\t\x1a\xea\x03\n\x08WorkFlow\x12\x0c\n\x04type\x18\x01 \x01(\t\x12\x61\n\x05wf_s1\x18\x02 \x01(\x0b\x32R.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1\x1a\xec\x02\n\x07WF_Sub1\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12q\n\x08wf_s1_s1\x18\x02 \x01(\x0b\x32_.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1\x1a\xdc\x01\n\x0cWF_Sub1_Sub1\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12x\n\x07routine\x18\x02 \x01(\x0b\x32g.google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.Routine\x1a\x41\n\x07Routine\x12\x12\n\nroutine_id\x18\x01 \x01(\t\x12\x0c\n\x04num2\x18\x02 \x01(\r\x12\x14\n\x0croutine_name\x18\x03 \x01(\t\x1a)\n\x05Part2\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x0f\n\x07string3\x18\x03 \x01(\t"4\n\x13GetHomeGraphRequest\x12\x0f\n\x07string1\x18\x03 \x01(\t\x12\x0c\n\x04num2\x18\x04 \x01(\t"\xbc\x37\n\x14GetHomeGraphResponse\x12\x12\n\ntimestamp1\x18\x01 \x01(\x04\x12\x46\n\x04home\x18\x02 \x01(\x0b\x32\x38.google.internal.home.foyer.v1.GetHomeGraphResponse.Home\x12I\n\x06groups\x18\x03 \x03(\x0b\x32\x39.google.internal.home.foyer.v1.GetHomeGraphResponse.Group\x12P\n\nroom_types\x18\x04 \x03(\x0b\x32<.google.internal.home.foyer.v1.GetHomeGraphResponse.RoomType\x12\x0f\n\x07string5\x18\x05 \x01(\t\x12\r\n\x05\x62ool6\x18\x06 \x01(\x08\x12T\n\x0c\x64\x65vice_types\x18\x07 \x03(\x0b\x32>.google.internal.home.foyer.v1.GetHomeGraphResponse.DeviceType\x12V\n\rproject_types\x18\t \x03(\x0b\x32?.google.internal.home.foyer.v1.GetHomeGraphResponse.ProjectType\x12P\n\tmessage11\x18\x0b \x03(\x0b\x32=.google.internal.home.foyer.v1.GetHomeGraphResponse.Message11\x12R\n\x0blinked_apps\x18\x0c \x03(\x0b\x32=.google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp\x1a\xc6\'\n\x04Home\x12\x0f\n\x07home_id\x18\x01 \x01(\t\x12\x11\n\thome_name\x18\x02 \x01(\t\x12S\n\x08location\x18\x03 \x01(\x0b\x32\x41.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location\x12Y\n\x0clinked_users\x18\x04 \x03(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.LinkedUser\x12L\n\x05rooms\x18\x06 \x03(\x0b\x32=.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room\x12P\n\x07\x64\x65vices\x18\x07 \x03(\x0b\x32?.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device\x12U\n\tmessage11\x18\x0b \x01(\x0b\x32\x42.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message11\x12\x10\n\x08string12\x18\x0c \x01(\t\x12U\n\tmessage13\x18\r \x01(\x0b\x32\x42.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13\x12\x11\n\tmessage14\x18\x0e \x01(\t\x12U\n\tmessage15\x18\x0f \x01(\x0b\x32\x42.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15\x1a\xd9\x01\n\x08Location\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x62\n\x0b\x63oordinates\x18\x02 \x01(\x0b\x32M.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.Coordinates\x12\x12\n\ntimestamp5\x18\x05 \x01(\x04\x12\x10\n\x08timezone\x18\x06 \x01(\t\x1a\x32\n\x0b\x43oordinates\x12\x10\n\x08latitude\x18\x01 \x01(\x01\x12\x11\n\tlongitude\x18\x02 \x01(\x01\x1a#\n\nLinkedUser\x12\x15\n\remail_address\x18\x01 \x01(\t\x1a\x9e\x01\n\x04Room\x12\x0f\n\x07room_id\x18\x01 \x01(\t\x12\x11\n\troom_name\x18\x03 \x01(\t\x12X\n\x08\x63\x61tegory\x18\x04 \x01(\x0b\x32\x46.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room.Category\x1a\x18\n\x08\x43\x61tegory\x12\x0c\n\x04name\x18\x01 \x01(\t\x1a\xbb\x18\n\x06\x44\x65vice\x12_\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32J.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo\x12\x13\n\x0b\x64\x65vice_name\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x06 \x01(\t\x12\x0e\n\x06traits\x18\x07 \x03(\t\x12\x0e\n\x06suffix\x18\n \x01(\t\x12\\\n\tmessage12\x18\x0c \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12\x12\\\n\tmessage15\x18\x0f \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message15\x12Z\n\x08hardware\x18\x11 \x01(\x0b\x32H.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Hardware\x12\\\n\tmessage18\x18\x12 \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message18\x12\x13\n\x0btimestamp19\x18\x13 \x01(\x04\x12\\\n\tmessage20\x18\x14 \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20\x12\\\n\tmessage25\x18\x19 \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message25\x12`\n\x0clinked_users\x18\x1a \x03(\x0b\x32J.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.LinkedUser\x12\x18\n\x10local_auth_token\x18\x1c \x01(\t\x12U\n\x06states\x18\x1d \x03(\x0b\x32\x45.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.State\x12\\\n\tmessage30\x18\x1e \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30\x12\\\n\tmessage34\x18" \x01(\x0b\x32I.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message34\x12\r\n\x05num37\x18% \x01(\r\x12\x10\n\x08string41\x18) \x01(\t\x12\x10\n\x08string42\x18* \x01(\t\x1a\xc1\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12h\n\nagent_info\x18\x02 \x01(\x0b\x32T.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1aq\n\tMessage12\x12\x0c\n\x04num2\x18\x02 \x01(\r\x12\x0c\n\x04num4\x18\x04 \x01(\r\x12\x0c\n\x04num5\x18\x05 \x01(\r\x12\r\n\x05num37\x18% \x01(\r\x12\r\n\x05num38\x18& \x01(\r\x12\r\n\x05num45\x18- \x01(\r\x12\r\n\x05num46\x18. \x01(\r\x1a\x43\n\tMessage15\x12\x0c\n\x04num1\x18\x01 \x01(\x04\x12\x0c\n\x04num5\x18\x05 \x01(\x04\x12\x0c\n\x04num6\x18\x06 \x01(\x04\x12\x0c\n\x04num7\x18\x07 \x01(\x04\x1a\x19\n\x08Hardware\x12\r\n\x05model\x18\x02 \x01(\t\x1a \n\tMessage18\x12\x13\n\x0b\x64\x65vice_name\x18\x02 \x01(\t\x1a\x88\x08\n\tMessage20\x12\x64\n\x08message1\x18\x01 \x03(\x0b\x32R.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1\x1a\x94\x07\n\x08Message1\x12\x0b\n\x03key\x18\x01 \x01(\t\x12g\n\x05value\x18\x02 \x01(\x0b\x32X.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value\x1a\x91\x06\n\x05Value\x12s\n\x08message6\x18\x06 \x01(\x0b\x32\x61.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6\x1a\x92\x05\n\x08Message6\x12|\n\x08message1\x18\x01 \x01(\x0b\x32j.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1\x1a\x87\x04\n\x08Message1\x12\x85\x01\n\x08message5\x18\x05 \x01(\x0b\x32s.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5\x1a\xf2\x02\n\x08Message5\x12\x8e\x01\n\x08message1\x18\x01 \x03(\x0b\x32|.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1\x1a\xd4\x01\n\x08Message1\x12\x12\n\ncapability\x18\x01 \x01(\t\x12\x98\x01\n\x08message2\x18\x02 \x01(\x0b\x32\x85\x01.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1.Message2\x1a\x19\n\x08Message2\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x1a)\n\tMessage25\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x12\r\n\x05\x62ool2\x18\x02 \x01(\x08\x1a#\n\nLinkedUser\x12\x15\n\remail_address\x18\x01 \x01(\t\x1a$\n\x05State\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c\x1a\xa6\x02\n\tMessage30\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x64\n\x08message2\x18\x02 \x01(\x0b\x32R.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2\x1a\xa5\x01\n\x08Message2\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12m\n\x08message2\x18\x02 \x01(\x0b\x32[.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2.Message2\x1a\x19\n\x08Message2\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x1a\x1a\n\tMessage34\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x1a\x1a\n\tMessage11\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x1a\xe4\x03\n\tMessage13\x12]\n\x08message1\x18\x01 \x01(\x0b\x32K.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1\x12\x14\n\x0c\x64uo_call_url\x18\x02 \x01(\t\x12\x18\n\x10\x64uo_phone_number\x18\x03 \x01(\t\x1a\xc7\x02\n\x08Message1\x12k\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32V.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo\x1a\xcd\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12t\n\nagent_info\x18\x02 \x01(\x0b\x32`.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1a\xbc\x02\n\tMessage15\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x12\x0f\n\x07string2\x18\x02 \x01(\t\x12]\n\x08message3\x18\x03 \x03(\x0b\x32K.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x1a\xa0\x01\n\x08Message3\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x66\n\x08message2\x18\x02 \x01(\x0b\x32T.google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3.Message2\x1a\x1b\n\x08Message2\x12\x0f\n\x07string1\x18\x01 \x01(\t\x1a\x87\x08\n\x05Group\x12Y\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32\x44.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo\x12\x12\n\ngroup_nmae\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65vice_type\x18\x06 \x01(\t\x12\x0e\n\x06traits\x18\x07 \x01(\t\x12\x0e\n\x06suffix\x18\n \x01(\t\x12V\n\tmessage12\x18\x0c \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message12\x12V\n\tmessage15\x18\x0f \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message15\x12V\n\tmessage17\x18\x11 \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message17\x12V\n\tmessage18\x18\x12 \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message18\x12\x13\n\x0btimestamp19\x18\x13 \x01(\x04\x12V\n\tmessage34\x18" \x01(\x0b\x32\x43.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message34\x1a\xa8\x01\n\nDeviceInfo\x12\x62\n\nagent_info\x18\x02 \x01(\x0b\x32N.google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1aI\n\tMessage12\x12\r\n\x05\x62ool3\x18\x03 \x01(\x08\x12\r\n\x05\x62ool4\x18\x04 \x01(\x08\x12\x0e\n\x06\x62ool37\x18% \x01(\x08\x12\x0e\n\x06\x62ool38\x18& \x01(\x08\x1a\x38\n\tMessage15\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x0c\n\x04num5\x18\x05 \x01(\x04\x12\x0c\n\x04num6\x18\x06 \x01(\r\x1a \n\tMessage17\x12\x13\n\x0bgroup_model\x18\x02 \x01(\t\x1a\x1f\n\tMessage18\x12\x12\n\ngroup_name\x18\x02 \x01(\t\x1a\x1a\n\tMessage34\x12\r\n\x05\x62ool1\x18\x01 \x01(\x08\x1a&\n\x08RoomType\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a(\n\nDeviceType\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a)\n\x0bProjectType\x12\x0c\n\x04\x63ode\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x1a\x8d\x01\n\tMessage11\x12\x0c\n\x04name\x18\x01 \x01(\t\x12X\n\x08message2\x18\x02 \x01(\x0b\x32\x46.google.internal.home.foyer.v1.GetHomeGraphResponse.Message11.Message2\x1a\x18\n\x08Message2\x12\x0c\n\x04num2\x18\x02 \x01(\r\x1aW\n\tLinkedApp\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x0f\n\x07string2\x18\x02 \x01(\t\x12\x0c\n\x04num3\x18\x03 \x01(\r\x12\x0c\n\x04num4\x18\x04 \x01(\r\x12\x0c\n\x04num5\x18\x05 \x01(\r"\xdb\x02\n!GetAssistantDeviceSettingsRequest\x12`\n\x0b\x64\x65vice_info\x18\x01 \x01(\x0b\x32K.google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo\x12\x0f\n\x07string2\x18\x02 \x01(\t\x1a\xc2\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12i\n\nagent_info\x18\x02 \x01(\x0b\x32U.google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t"\xe6\x01\n"GetAssistantDeviceSettingsResponse\x12\\\n\x08message1\x18\x01 \x01(\x0b\x32J.google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1\x1a\x62\n\x08Message1\x12\x0c\n\x04num1\x18\x01 \x01(\r\x12\x0c\n\x04num2\x18\x02 \x01(\r\x12\x0c\n\x04num4\x18\x04 \x01(\r\x12\x0c\n\x04num5\x18\x05 \x01(\r\x12\x0c\n\x04num6\x18\x06 \x01(\r\x12\x10\n\x08string10\x18\n \x01(\t"\xa3\x05\n$UpdateAssistantDeviceSettingsRequest\x12\x0f\n\x07string1\x18\x01 \x01(\t\x12\x63\n\x0b\x64\x65vice_info\x18\x02 \x01(\x0b\x32N.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo\x12\x63\n\x0bupdate_data\x18\x03 \x01(\x0b\x32N.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData\x1a\xc5\x01\n\nDeviceInfo\x12\x11\n\tdevice_id\x18\x01 \x01(\t\x12l\n\nagent_info\x18\x02 \x01(\x0b\x32X.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo\x1a\x36\n\tAgentInfo\x12\x16\n\x0e\x61pi_project_id\x18\x01 \x01(\t\x12\x11\n\tunique_id\x18\x02 \x01(\t\x1a\xd7\x01\n\nUpdateData\x12i\n\x08message1\x18\x01 \x01(\x0b\x32W.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData.Message1\x1a^\n\x08Message1\x12\x1f\n\x17youtube_restricted_mode\x18\x04 \x01(\r\x12!\n\x19youtube_tv_content_filter\x18\x05 \x01(\r\x12\x0e\n\x06locale\x18\n \x01(\t"8\n%UpdateAssistantDeviceSettingsResponse\x12\x0f\n\x07string1\x18\x01 \x01(\t2\xa8\x01\n\x12HomeControlService\x12\x91\x01\n\x14GetAssistantRoutines\x12:.google.internal.home.foyer.v1.GetAssistantRoutinesRequest\x1a;.google.internal.home.foyer.v1.GetAssistantRoutinesResponse0\x01\x32\x8c\x01\n\x11StructuresService\x12w\n\x0cGetHomeGraph\x12\x32.google.internal.home.foyer.v1.GetHomeGraphRequest\x1a\x33.google.internal.home.foyer.v1.GetHomeGraphResponse2\xe9\x02\n\x12HomeDevicesService\x12\xa3\x01\n\x1aGetAssistantDeviceSettings\x12@.google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest\x1a\x41.google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse0\x01\x12\xac\x01\n\x1dUpdateAssistantDeviceSettings\x12\x43.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest\x1a\x44.google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsResponse0\x01\x62\x06proto3',
 )
 
 
-_GETASSISTANTROUTINESREQUEST = DESCRIPTOR.message_types_by_name[
+_GETASSISTANTROUTINESREQUEST = _descriptor.Descriptor(
+    name="GetAssistantRoutinesRequest",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesRequest",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=70,
+    serialized_end=99,
+)
+
+
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1_ROUTINE = _descriptor.Descriptor(
+    name="Routine",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.Routine",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="routine_id",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.Routine.routine_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num2",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.Routine.num2",
+            index=1,
+            number=2,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="routine_name",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.Routine.routine_name",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=878,
+    serialized_end=943,
+)
+
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1 = _descriptor.Descriptor(
+    name="WF_Sub1_Sub1",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="routine",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.WF_Sub1_Sub1.routine",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1_ROUTINE,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=723,
+    serialized_end=943,
+)
+
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1 = _descriptor.Descriptor(
+    name="WF_Sub1",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="wf_s1_s1",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.WF_Sub1.wf_s1_s1",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=579,
+    serialized_end=943,
+)
+
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW = _descriptor.Descriptor(
+    name="WorkFlow",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="type",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.type",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="wf_s1",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.WorkFlow.wf_s1",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=453,
+    serialized_end=943,
+)
+
+_GETASSISTANTROUTINESRESPONSE_PART1 = _descriptor.Descriptor(
+    name="Part1",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="routine_name",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.routine_name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="workflow",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.workflow",
+            index=1,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string4",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.string4",
+            index=2,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string5",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part1.string5",
+            index=3,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=293,
+    serialized_end=943,
+)
+
+_GETASSISTANTROUTINESRESPONSE_PART2 = _descriptor.Descriptor(
+    name="Part2",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part2",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part2.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string3",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.Part2.string3",
+            index=1,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=945,
+    serialized_end=986,
+)
+
+_GETASSISTANTROUTINESRESPONSE = _descriptor.Descriptor(
+    name="GetAssistantRoutinesResponse",
+    full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="p1",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.p1",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="p2",
+            full_name="google.internal.home.foyer.v1.GetAssistantRoutinesResponse.p2",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTROUTINESRESPONSE_PART1,
+        _GETASSISTANTROUTINESRESPONSE_PART2,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=102,
+    serialized_end=986,
+)
+
+
+_GETHOMEGRAPHREQUEST = _descriptor.Descriptor(
+    name="GetHomeGraphRequest",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphRequest",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphRequest.string1",
+            index=0,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphRequest.num2",
+            index=1,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=988,
+    serialized_end=1040,
+)
+
+
+_GETHOMEGRAPHRESPONSE_HOME_LOCATION_COORDINATES = _descriptor.Descriptor(
+    name="Coordinates",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.Coordinates",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="latitude",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.Coordinates.latitude",
+            index=0,
+            number=1,
+            type=1,
+            cpp_type=5,
+            label=1,
+            has_default_value=False,
+            default_value=float(0),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="longitude",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.Coordinates.longitude",
+            index=1,
+            number=2,
+            type=1,
+            cpp_type=5,
+            label=1,
+            has_default_value=False,
+            default_value=float(0),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2535,
+    serialized_end=2585,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_LOCATION = _descriptor.Descriptor(
+    name="Location",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="address",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.address",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="coordinates",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.coordinates",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="timestamp5",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.timestamp5",
+            index=2,
+            number=5,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="timezone",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Location.timezone",
+            index=3,
+            number=6,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_LOCATION_COORDINATES,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2368,
+    serialized_end=2585,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_LINKEDUSER = _descriptor.Descriptor(
+    name="LinkedUser",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.LinkedUser",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="email_address",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.LinkedUser.email_address",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2587,
+    serialized_end=2622,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_ROOM_CATEGORY = _descriptor.Descriptor(
+    name="Category",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room.Category",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room.Category.name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2759,
+    serialized_end=2783,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_ROOM = _descriptor.Descriptor(
+    name="Room",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="room_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room.room_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="room_name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room.room_name",
+            index=1,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="category",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Room.category",
+            index=2,
+            number=4,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_ROOM_CATEGORY,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2625,
+    serialized_end=2783,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO_AGENTINFO = _descriptor.Descriptor(
+    name="AgentInfo",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo.AgentInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="api_project_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo.AgentInfo.api_project_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="unique_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo.AgentInfo.unique_id",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4140,
+    serialized_end=4194,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO = _descriptor.Descriptor(
+    name="DeviceInfo",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo.device_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="agent_info",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.DeviceInfo.agent_info",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO_AGENTINFO,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4001,
+    serialized_end=4194,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE12 = _descriptor.Descriptor(
+    name="Message12",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="num2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12.num2",
+            index=0,
+            number=2,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num4",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12.num4",
+            index=1,
+            number=4,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num5",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12.num5",
+            index=2,
+            number=5,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num37",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12.num37",
+            index=3,
+            number=37,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num38",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12.num38",
+            index=4,
+            number=38,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num45",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12.num45",
+            index=5,
+            number=45,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num46",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message12.num46",
+            index=6,
+            number=46,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4196,
+    serialized_end=4309,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE15 = _descriptor.Descriptor(
+    name="Message15",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message15",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="num1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message15.num1",
+            index=0,
+            number=1,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num5",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message15.num5",
+            index=1,
+            number=5,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num6",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message15.num6",
+            index=2,
+            number=6,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num7",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message15.num7",
+            index=3,
+            number=7,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4311,
+    serialized_end=4378,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_HARDWARE = _descriptor.Descriptor(
+    name="Hardware",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Hardware",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="model",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Hardware.model",
+            index=0,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4380,
+    serialized_end=4405,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE18 = _descriptor.Descriptor(
+    name="Message18",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message18",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message18.device_name",
+            index=0,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4407,
+    serialized_end=4439,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1_MESSAGE2 = _descriptor.Descriptor(
+    name="Message2",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1.Message2",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool4",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1.Message2.bool4",
+            index=0,
+            number=4,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5449,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1 = _descriptor.Descriptor(
+    name="Message1",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="capability",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1.capability",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.Message1.message2",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1_MESSAGE2,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5262,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5 = _descriptor.Descriptor(
+    name="Message5",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.Message5.message1",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5104,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1 = _descriptor.Descriptor(
+    name="Message1",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message5",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.Message1.message5",
+            index=0,
+            number=5,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4955,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6 = _descriptor.Descriptor(
+    name="Message6",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.Message6.message1",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4816,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE = _descriptor.Descriptor(
+    name="Value",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message6",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.Value.message6",
+            index=0,
+            number=6,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4689,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1 = _descriptor.Descriptor(
+    name="Message1",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="key",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.key",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="value",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.Message1.value",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4558,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20 = _descriptor.Descriptor(
+    name="Message20",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message20.message1",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4442,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE25 = _descriptor.Descriptor(
+    name="Message25",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message25",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message25.bool1",
+            index=0,
+            number=1,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="bool2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message25.bool2",
+            index=1,
+            number=2,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5476,
+    serialized_end=5517,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_LINKEDUSER = _descriptor.Descriptor(
+    name="LinkedUser",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.LinkedUser",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="email_address",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.LinkedUser.email_address",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2587,
+    serialized_end=2622,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_STATE = _descriptor.Descriptor(
+    name="State",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.State",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.State.name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="value",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.State.value",
+            index=1,
+            number=2,
+            type=12,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"",
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5556,
+    serialized_end=5592,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2_MESSAGE2 = _descriptor.Descriptor(
+    name="Message2",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2.Message2",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool4",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2.Message2.bool4",
+            index=0,
+            number=4,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5449,
+    serialized_end=5474,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2 = _descriptor.Descriptor(
+    name="Message2",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.Message2.message2",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2_MESSAGE2,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5724,
+    serialized_end=5889,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30 = _descriptor.Descriptor(
+    name="Message30",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="key",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.key",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message30.message2",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5595,
+    serialized_end=5889,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE34 = _descriptor.Descriptor(
+    name="Message34",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message34",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.Message34.bool1",
+            index=0,
+            number=1,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5891,
+    serialized_end=5917,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE = _descriptor.Descriptor(
+    name="Device",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_info",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.device_info",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="device_name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.device_name",
+            index=1,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="device_type",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.device_type",
+            index=2,
+            number=6,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="traits",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.traits",
+            index=3,
+            number=7,
+            type=9,
+            cpp_type=9,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="suffix",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.suffix",
+            index=4,
+            number=10,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message12",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.message12",
+            index=5,
+            number=12,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message15",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.message15",
+            index=6,
+            number=15,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="hardware",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.hardware",
+            index=7,
+            number=17,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message18",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.message18",
+            index=8,
+            number=18,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="timestamp19",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.timestamp19",
+            index=9,
+            number=19,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message20",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.message20",
+            index=10,
+            number=20,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message25",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.message25",
+            index=11,
+            number=25,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="linked_users",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.linked_users",
+            index=12,
+            number=26,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="local_auth_token",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.local_auth_token",
+            index=13,
+            number=28,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="states",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.states",
+            index=14,
+            number=29,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message30",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.message30",
+            index=15,
+            number=30,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message34",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.message34",
+            index=16,
+            number=34,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num37",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.num37",
+            index=17,
+            number=37,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string41",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.string41",
+            index=18,
+            number=41,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string42",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Device.string42",
+            index=19,
+            number=42,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE12,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE15,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_HARDWARE,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE18,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE25,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_LINKEDUSER,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_STATE,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE34,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=2786,
+    serialized_end=5917,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE11 = _descriptor.Descriptor(
+    name="Message11",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message11",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message11.bool1",
+            index=0,
+            number=1,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5919,
+    serialized_end=5945,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO_AGENTINFO = _descriptor.Descriptor(
+    name="AgentInfo",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo.AgentInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="api_project_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo.AgentInfo.api_project_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="unique_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo.AgentInfo.unique_id",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4140,
+    serialized_end=4194,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO = _descriptor.Descriptor(
+    name="DeviceInfo",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo.device_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="agent_info",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.DeviceInfo.agent_info",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO_AGENTINFO,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=6227,
+    serialized_end=6432,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1 = _descriptor.Descriptor(
+    name="Message1",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_info",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.Message1.device_info",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=6105,
+    serialized_end=6432,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13 = _descriptor.Descriptor(
+    name="Message13",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.message1",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="duo_call_url",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.duo_call_url",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="duo_phone_number",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message13.duo_phone_number",
+            index=2,
+            number=3,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5948,
+    serialized_end=6432,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3_MESSAGE2 = _descriptor.Descriptor(
+    name="Message2",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3.Message2",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3.Message2.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5724,
+    serialized_end=5751,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3 = _descriptor.Descriptor(
+    name="Message3",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.Message3.message2",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3_MESSAGE2,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=6591,
+    serialized_end=6751,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15 = _descriptor.Descriptor(
+    name="Message15",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.bool1",
+            index=0,
+            number=1,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.string2",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message3",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.message3",
+            index=2,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="bool4",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.Message15.bool4",
+            index=3,
+            number=4,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=6435,
+    serialized_end=6751,
+)
+
+_GETHOMEGRAPHRESPONSE_HOME = _descriptor.Descriptor(
+    name="Home",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="home_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.home_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="home_name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.home_name",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="location",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.location",
+            index=2,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="linked_users",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.linked_users",
+            index=3,
+            number=4,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="rooms",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.rooms",
+            index=4,
+            number=6,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="devices",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.devices",
+            index=5,
+            number=7,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message11",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.message11",
+            index=6,
+            number=11,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string12",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.string12",
+            index=7,
+            number=12,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message13",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.message13",
+            index=8,
+            number=13,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message14",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.message14",
+            index=9,
+            number=14,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message15",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Home.message15",
+            index=10,
+            number=15,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME_LOCATION,
+        _GETHOMEGRAPHRESPONSE_HOME_LINKEDUSER,
+        _GETHOMEGRAPHRESPONSE_HOME_ROOM,
+        _GETHOMEGRAPHRESPONSE_HOME_DEVICE,
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE11,
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13,
+        _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=1689,
+    serialized_end=6751,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO_AGENTINFO = _descriptor.Descriptor(
+    name="AgentInfo",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo.AgentInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="api_project_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo.AgentInfo.api_project_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="unique_id",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo.AgentInfo.unique_id",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4140,
+    serialized_end=4194,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO = _descriptor.Descriptor(
+    name="DeviceInfo",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="agent_info",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.DeviceInfo.agent_info",
+            index=0,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO_AGENTINFO,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7389,
+    serialized_end=7557,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE12 = _descriptor.Descriptor(
+    name="Message12",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message12",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool3",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message12.bool3",
+            index=0,
+            number=3,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="bool4",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message12.bool4",
+            index=1,
+            number=4,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="bool37",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message12.bool37",
+            index=2,
+            number=37,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="bool38",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message12.bool38",
+            index=3,
+            number=38,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7559,
+    serialized_end=7632,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE15 = _descriptor.Descriptor(
+    name="Message15",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message15",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message15.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num5",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message15.num5",
+            index=1,
+            number=5,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num6",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message15.num6",
+            index=2,
+            number=6,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7634,
+    serialized_end=7690,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE17 = _descriptor.Descriptor(
+    name="Message17",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message17",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="group_model",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message17.group_model",
+            index=0,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7692,
+    serialized_end=7724,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE18 = _descriptor.Descriptor(
+    name="Message18",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message18",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="group_name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message18.group_name",
+            index=0,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7726,
+    serialized_end=7757,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE34 = _descriptor.Descriptor(
+    name="Message34",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message34",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="bool1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.Message34.bool1",
+            index=0,
+            number=1,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=5891,
+    serialized_end=5917,
+)
+
+_GETHOMEGRAPHRESPONSE_GROUP = _descriptor.Descriptor(
+    name="Group",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_info",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.device_info",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="group_nmae",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.group_nmae",
+            index=1,
+            number=4,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="device_type",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.device_type",
+            index=2,
+            number=6,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="traits",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.traits",
+            index=3,
+            number=7,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="suffix",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.suffix",
+            index=4,
+            number=10,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message12",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.message12",
+            index=5,
+            number=12,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message15",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.message15",
+            index=6,
+            number=15,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message17",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.message17",
+            index=7,
+            number=17,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message18",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.message18",
+            index=8,
+            number=18,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="timestamp19",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.timestamp19",
+            index=9,
+            number=19,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message34",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Group.message34",
+            index=10,
+            number=34,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO,
+        _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE12,
+        _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE15,
+        _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE17,
+        _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE18,
+        _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE34,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=6754,
+    serialized_end=7785,
+)
+
+_GETHOMEGRAPHRESPONSE_ROOMTYPE = _descriptor.Descriptor(
+    name="RoomType",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.RoomType",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="code",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.RoomType.code",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.RoomType.name",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7787,
+    serialized_end=7825,
+)
+
+_GETHOMEGRAPHRESPONSE_DEVICETYPE = _descriptor.Descriptor(
+    name="DeviceType",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.DeviceType",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="code",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.DeviceType.code",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.DeviceType.name",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7827,
+    serialized_end=7867,
+)
+
+_GETHOMEGRAPHRESPONSE_PROJECTTYPE = _descriptor.Descriptor(
+    name="ProjectType",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.ProjectType",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="code",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.ProjectType.code",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.ProjectType.name",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7869,
+    serialized_end=7910,
+)
+
+_GETHOMEGRAPHRESPONSE_MESSAGE11_MESSAGE2 = _descriptor.Descriptor(
+    name="Message2",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Message11.Message2",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="num2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Message11.Message2.num2",
+            index=0,
+            number=2,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8030,
+    serialized_end=8054,
+)
+
+_GETHOMEGRAPHRESPONSE_MESSAGE11 = _descriptor.Descriptor(
+    name="Message11",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Message11",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="name",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Message11.name",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.Message11.message2",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_MESSAGE11_MESSAGE2,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=7913,
+    serialized_end=8054,
+)
+
+_GETHOMEGRAPHRESPONSE_LINKEDAPP = _descriptor.Descriptor(
+    name="LinkedApp",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string2",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp.string2",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num3",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp.num3",
+            index=2,
+            number=3,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num4",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp.num4",
+            index=3,
+            number=4,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num5",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.LinkedApp.num5",
+            index=4,
+            number=5,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8056,
+    serialized_end=8143,
+)
+
+_GETHOMEGRAPHRESPONSE = _descriptor.Descriptor(
+    name="GetHomeGraphResponse",
+    full_name="google.internal.home.foyer.v1.GetHomeGraphResponse",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="timestamp1",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.timestamp1",
+            index=0,
+            number=1,
+            type=4,
+            cpp_type=4,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="home",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.home",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="groups",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.groups",
+            index=2,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="room_types",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.room_types",
+            index=3,
+            number=4,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string5",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.string5",
+            index=4,
+            number=5,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="bool6",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.bool6",
+            index=5,
+            number=6,
+            type=8,
+            cpp_type=7,
+            label=1,
+            has_default_value=False,
+            default_value=False,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="device_types",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.device_types",
+            index=6,
+            number=7,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="project_types",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.project_types",
+            index=7,
+            number=9,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="message11",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.message11",
+            index=8,
+            number=11,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="linked_apps",
+            full_name="google.internal.home.foyer.v1.GetHomeGraphResponse.linked_apps",
+            index=9,
+            number=12,
+            type=11,
+            cpp_type=10,
+            label=3,
+            has_default_value=False,
+            default_value=[],
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETHOMEGRAPHRESPONSE_HOME,
+        _GETHOMEGRAPHRESPONSE_GROUP,
+        _GETHOMEGRAPHRESPONSE_ROOMTYPE,
+        _GETHOMEGRAPHRESPONSE_DEVICETYPE,
+        _GETHOMEGRAPHRESPONSE_PROJECTTYPE,
+        _GETHOMEGRAPHRESPONSE_MESSAGE11,
+        _GETHOMEGRAPHRESPONSE_LINKEDAPP,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=1043,
+    serialized_end=8143,
+)
+
+
+_GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO = _descriptor.Descriptor(
+    name="AgentInfo",
+    full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="api_project_id",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo.api_project_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="unique_id",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo.unique_id",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4140,
+    serialized_end=4194,
+)
+
+_GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO = _descriptor.Descriptor(
+    name="DeviceInfo",
+    full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_id",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo.device_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="agent_info",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.DeviceInfo.agent_info",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8299,
+    serialized_end=8493,
+)
+
+_GETASSISTANTDEVICESETTINGSREQUEST = _descriptor.Descriptor(
+    name="GetAssistantDeviceSettingsRequest",
+    full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_info",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.device_info",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string2",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsRequest.string2",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8146,
+    serialized_end=8493,
+)
+
+
+_GETASSISTANTDEVICESETTINGSRESPONSE_MESSAGE1 = _descriptor.Descriptor(
+    name="Message1",
+    full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="num1",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1.num1",
+            index=0,
+            number=1,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num2",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1.num2",
+            index=1,
+            number=2,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num4",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1.num4",
+            index=2,
+            number=4,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num5",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1.num5",
+            index=3,
+            number=5,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="num6",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1.num6",
+            index=4,
+            number=6,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="string10",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.Message1.string10",
+            index=5,
+            number=10,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8628,
+    serialized_end=8726,
+)
+
+_GETASSISTANTDEVICESETTINGSRESPONSE = _descriptor.Descriptor(
+    name="GetAssistantDeviceSettingsResponse",
+    full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message1",
+            full_name="google.internal.home.foyer.v1.GetAssistantDeviceSettingsResponse.message1",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _GETASSISTANTDEVICESETTINGSRESPONSE_MESSAGE1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8496,
+    serialized_end=8726,
+)
+
+
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO = _descriptor.Descriptor(
+    name="AgentInfo",
+    full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="api_project_id",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo.api_project_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="unique_id",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo.AgentInfo.unique_id",
+            index=1,
+            number=2,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=4140,
+    serialized_end=4194,
+)
+
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO = _descriptor.Descriptor(
+    name="DeviceInfo",
+    full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="device_id",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo.device_id",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="agent_info",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.DeviceInfo.agent_info",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8989,
+    serialized_end=9186,
+)
+
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA_MESSAGE1 = _descriptor.Descriptor(
+    name="Message1",
+    full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData.Message1",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="youtube_restricted_mode",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData.Message1.youtube_restricted_mode",
+            index=0,
+            number=4,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="youtube_tv_content_filter",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData.Message1.youtube_tv_content_filter",
+            index=1,
+            number=5,
+            type=13,
+            cpp_type=3,
+            label=1,
+            has_default_value=False,
+            default_value=0,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="locale",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData.Message1.locale",
+            index=2,
+            number=10,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=9310,
+    serialized_end=9404,
+)
+
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA = _descriptor.Descriptor(
+    name="UpdateData",
+    full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="message1",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.UpdateData.message1",
+            index=0,
+            number=1,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA_MESSAGE1,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=9189,
+    serialized_end=9404,
+)
+
+_UPDATEASSISTANTDEVICESETTINGSREQUEST = _descriptor.Descriptor(
+    name="UpdateAssistantDeviceSettingsRequest",
+    full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="device_info",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.device_info",
+            index=1,
+            number=2,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.FieldDescriptor(
+            name="update_data",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsRequest.update_data",
+            index=2,
+            number=3,
+            type=11,
+            cpp_type=10,
+            label=1,
+            has_default_value=False,
+            default_value=None,
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[
+        _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO,
+        _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA,
+    ],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=8729,
+    serialized_end=9404,
+)
+
+
+_UPDATEASSISTANTDEVICESETTINGSRESPONSE = _descriptor.Descriptor(
+    name="UpdateAssistantDeviceSettingsResponse",
+    full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsResponse",
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    create_key=_descriptor._internal_create_key,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name="string1",
+            full_name="google.internal.home.foyer.v1.UpdateAssistantDeviceSettingsResponse.string1",
+            index=0,
+            number=1,
+            type=9,
+            cpp_type=9,
+            label=1,
+            has_default_value=False,
+            default_value=b"".decode("utf-8"),
+            message_type=None,
+            enum_type=None,
+            containing_type=None,
+            is_extension=False,
+            extension_scope=None,
+            serialized_options=None,
+            file=DESCRIPTOR,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    serialized_options=None,
+    is_extendable=False,
+    syntax="proto3",
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=9406,
+    serialized_end=9462,
+)
+
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1_ROUTINE.containing_type = (
+    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1
+)
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1.fields_by_name[
+    "routine"
+].message_type = (
+    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1_ROUTINE
+)
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1.containing_type = (
+    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1
+)
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1.fields_by_name[
+    "wf_s1_s1"
+].message_type = _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1.containing_type = (
+    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW
+)
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW.fields_by_name[
+    "wf_s1"
+].message_type = _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1
+_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW.containing_type = (
+    _GETASSISTANTROUTINESRESPONSE_PART1
+)
+_GETASSISTANTROUTINESRESPONSE_PART1.fields_by_name[
+    "workflow"
+].message_type = _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW
+_GETASSISTANTROUTINESRESPONSE_PART1.containing_type = _GETASSISTANTROUTINESRESPONSE
+_GETASSISTANTROUTINESRESPONSE_PART2.containing_type = _GETASSISTANTROUTINESRESPONSE
+_GETASSISTANTROUTINESRESPONSE.fields_by_name[
+    "p1"
+].message_type = _GETASSISTANTROUTINESRESPONSE_PART1
+_GETASSISTANTROUTINESRESPONSE.fields_by_name[
+    "p2"
+].message_type = _GETASSISTANTROUTINESRESPONSE_PART2
+_GETHOMEGRAPHRESPONSE_HOME_LOCATION_COORDINATES.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_LOCATION
+)
+_GETHOMEGRAPHRESPONSE_HOME_LOCATION.fields_by_name[
+    "coordinates"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_LOCATION_COORDINATES
+_GETHOMEGRAPHRESPONSE_HOME_LOCATION.containing_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE_HOME_LINKEDUSER.containing_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE_HOME_ROOM_CATEGORY.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_ROOM
+)
+_GETHOMEGRAPHRESPONSE_HOME_ROOM.fields_by_name[
+    "category"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_ROOM_CATEGORY
+_GETHOMEGRAPHRESPONSE_HOME_ROOM.containing_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO_AGENTINFO.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO.fields_by_name[
+    "agent_info"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO_AGENTINFO
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE12.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE15.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_HARDWARE.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE18.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1_MESSAGE2.containing_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1.fields_by_name[
+    "message2"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1_MESSAGE2
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1.containing_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5.fields_by_name[
+    "message1"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1.fields_by_name[
+    "message5"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6.fields_by_name[
+    "message1"
+].message_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE.fields_by_name[
+    "message6"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1.fields_by_name[
+    "value"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20.fields_by_name[
+    "message1"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE25.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_LINKEDUSER.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_STATE.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2_MESSAGE2.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2.fields_by_name[
+    "message2"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2_MESSAGE2
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30.fields_by_name[
+    "message2"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE34.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+)
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "device_info"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "message12"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE12
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "message15"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE15
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "hardware"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_HARDWARE
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "message18"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE18
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "message20"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "message25"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE25
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "linked_users"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_LINKEDUSER
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "states"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_STATE
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "message30"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.fields_by_name[
+    "message34"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE34
+_GETHOMEGRAPHRESPONSE_HOME_DEVICE.containing_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE11.containing_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO_AGENTINFO.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO
+)
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO.fields_by_name[
+    "agent_info"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO_AGENTINFO
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1
+)
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1.fields_by_name[
+    "device_info"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13
+)
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13.fields_by_name[
+    "message1"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13.containing_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3_MESSAGE2.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3
+)
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3.fields_by_name[
+    "message2"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3_MESSAGE2
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3.containing_type = (
+    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15
+)
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15.fields_by_name[
+    "message3"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3
+_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15.containing_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE_HOME.fields_by_name[
+    "location"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_LOCATION
+_GETHOMEGRAPHRESPONSE_HOME.fields_by_name[
+    "linked_users"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_LINKEDUSER
+_GETHOMEGRAPHRESPONSE_HOME.fields_by_name[
+    "rooms"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_ROOM
+_GETHOMEGRAPHRESPONSE_HOME.fields_by_name[
+    "devices"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_DEVICE
+_GETHOMEGRAPHRESPONSE_HOME.fields_by_name[
+    "message11"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE11
+_GETHOMEGRAPHRESPONSE_HOME.fields_by_name[
+    "message13"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13
+_GETHOMEGRAPHRESPONSE_HOME.fields_by_name[
+    "message15"
+].message_type = _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15
+_GETHOMEGRAPHRESPONSE_HOME.containing_type = _GETHOMEGRAPHRESPONSE
+_GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO_AGENTINFO.containing_type = (
+    _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO
+)
+_GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO.fields_by_name[
+    "agent_info"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO_AGENTINFO
+_GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO.containing_type = _GETHOMEGRAPHRESPONSE_GROUP
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE12.containing_type = _GETHOMEGRAPHRESPONSE_GROUP
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE15.containing_type = _GETHOMEGRAPHRESPONSE_GROUP
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE17.containing_type = _GETHOMEGRAPHRESPONSE_GROUP
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE18.containing_type = _GETHOMEGRAPHRESPONSE_GROUP
+_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE34.containing_type = _GETHOMEGRAPHRESPONSE_GROUP
+_GETHOMEGRAPHRESPONSE_GROUP.fields_by_name[
+    "device_info"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO
+_GETHOMEGRAPHRESPONSE_GROUP.fields_by_name[
+    "message12"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE12
+_GETHOMEGRAPHRESPONSE_GROUP.fields_by_name[
+    "message15"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE15
+_GETHOMEGRAPHRESPONSE_GROUP.fields_by_name[
+    "message17"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE17
+_GETHOMEGRAPHRESPONSE_GROUP.fields_by_name[
+    "message18"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE18
+_GETHOMEGRAPHRESPONSE_GROUP.fields_by_name[
+    "message34"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE34
+_GETHOMEGRAPHRESPONSE_GROUP.containing_type = _GETHOMEGRAPHRESPONSE
+_GETHOMEGRAPHRESPONSE_ROOMTYPE.containing_type = _GETHOMEGRAPHRESPONSE
+_GETHOMEGRAPHRESPONSE_DEVICETYPE.containing_type = _GETHOMEGRAPHRESPONSE
+_GETHOMEGRAPHRESPONSE_PROJECTTYPE.containing_type = _GETHOMEGRAPHRESPONSE
+_GETHOMEGRAPHRESPONSE_MESSAGE11_MESSAGE2.containing_type = (
+    _GETHOMEGRAPHRESPONSE_MESSAGE11
+)
+_GETHOMEGRAPHRESPONSE_MESSAGE11.fields_by_name[
+    "message2"
+].message_type = _GETHOMEGRAPHRESPONSE_MESSAGE11_MESSAGE2
+_GETHOMEGRAPHRESPONSE_MESSAGE11.containing_type = _GETHOMEGRAPHRESPONSE
+_GETHOMEGRAPHRESPONSE_LINKEDAPP.containing_type = _GETHOMEGRAPHRESPONSE
+_GETHOMEGRAPHRESPONSE.fields_by_name["home"].message_type = _GETHOMEGRAPHRESPONSE_HOME
+_GETHOMEGRAPHRESPONSE.fields_by_name[
+    "groups"
+].message_type = _GETHOMEGRAPHRESPONSE_GROUP
+_GETHOMEGRAPHRESPONSE.fields_by_name[
+    "room_types"
+].message_type = _GETHOMEGRAPHRESPONSE_ROOMTYPE
+_GETHOMEGRAPHRESPONSE.fields_by_name[
+    "device_types"
+].message_type = _GETHOMEGRAPHRESPONSE_DEVICETYPE
+_GETHOMEGRAPHRESPONSE.fields_by_name[
+    "project_types"
+].message_type = _GETHOMEGRAPHRESPONSE_PROJECTTYPE
+_GETHOMEGRAPHRESPONSE.fields_by_name[
+    "message11"
+].message_type = _GETHOMEGRAPHRESPONSE_MESSAGE11
+_GETHOMEGRAPHRESPONSE.fields_by_name[
+    "linked_apps"
+].message_type = _GETHOMEGRAPHRESPONSE_LINKEDAPP
+_GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO.containing_type = (
+    _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO
+)
+_GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO.fields_by_name[
+    "agent_info"
+].message_type = _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO
+_GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO.containing_type = (
+    _GETASSISTANTDEVICESETTINGSREQUEST
+)
+_GETASSISTANTDEVICESETTINGSREQUEST.fields_by_name[
+    "device_info"
+].message_type = _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO
+_GETASSISTANTDEVICESETTINGSRESPONSE_MESSAGE1.containing_type = (
+    _GETASSISTANTDEVICESETTINGSRESPONSE
+)
+_GETASSISTANTDEVICESETTINGSRESPONSE.fields_by_name[
+    "message1"
+].message_type = _GETASSISTANTDEVICESETTINGSRESPONSE_MESSAGE1
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO.containing_type = (
+    _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO
+)
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO.fields_by_name[
+    "agent_info"
+].message_type = _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO.containing_type = (
+    _UPDATEASSISTANTDEVICESETTINGSREQUEST
+)
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA_MESSAGE1.containing_type = (
+    _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA
+)
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA.fields_by_name[
+    "message1"
+].message_type = _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA_MESSAGE1
+_UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA.containing_type = (
+    _UPDATEASSISTANTDEVICESETTINGSREQUEST
+)
+_UPDATEASSISTANTDEVICESETTINGSREQUEST.fields_by_name[
+    "device_info"
+].message_type = _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO
+_UPDATEASSISTANTDEVICESETTINGSREQUEST.fields_by_name[
+    "update_data"
+].message_type = _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA
+DESCRIPTOR.message_types_by_name[
     "GetAssistantRoutinesRequest"
-]
-_GETASSISTANTROUTINESRESPONSE = DESCRIPTOR.message_types_by_name[
+] = _GETASSISTANTROUTINESREQUEST
+DESCRIPTOR.message_types_by_name[
     "GetAssistantRoutinesResponse"
-]
-_GETASSISTANTROUTINESRESPONSE_PART1 = (
-    _GETASSISTANTROUTINESRESPONSE.nested_types_by_name["Part1"]
-)
-_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW = (
-    _GETASSISTANTROUTINESRESPONSE_PART1.nested_types_by_name["WorkFlow"]
-)
-_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1 = (
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW.nested_types_by_name["WF_Sub1"]
-)
-_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1 = (
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1.nested_types_by_name[
-        "WF_Sub1_Sub1"
-    ]
-)
-_GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1_ROUTINE = _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1.nested_types_by_name[
-    "Routine"
-]
-_GETASSISTANTROUTINESRESPONSE_PART2 = (
-    _GETASSISTANTROUTINESRESPONSE.nested_types_by_name["Part2"]
-)
-_GETHOMEGRAPHREQUEST = DESCRIPTOR.message_types_by_name["GetHomeGraphRequest"]
-_GETHOMEGRAPHRESPONSE = DESCRIPTOR.message_types_by_name["GetHomeGraphResponse"]
-_GETHOMEGRAPHRESPONSE_HOME = _GETHOMEGRAPHRESPONSE.nested_types_by_name["Home"]
-_GETHOMEGRAPHRESPONSE_HOME_LOCATION = _GETHOMEGRAPHRESPONSE_HOME.nested_types_by_name[
-    "Location"
-]
-_GETHOMEGRAPHRESPONSE_HOME_LOCATION_COORDINATES = (
-    _GETHOMEGRAPHRESPONSE_HOME_LOCATION.nested_types_by_name["Coordinates"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_LINKEDUSER = _GETHOMEGRAPHRESPONSE_HOME.nested_types_by_name[
-    "LinkedUser"
-]
-_GETHOMEGRAPHRESPONSE_HOME_ROOM = _GETHOMEGRAPHRESPONSE_HOME.nested_types_by_name[
-    "Room"
-]
-_GETHOMEGRAPHRESPONSE_HOME_ROOM_CATEGORY = (
-    _GETHOMEGRAPHRESPONSE_HOME_ROOM.nested_types_by_name["Category"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE = _GETHOMEGRAPHRESPONSE_HOME.nested_types_by_name[
-    "Device"
-]
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["DeviceInfo"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO_AGENTINFO = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO.nested_types_by_name["AgentInfo"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE12 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Message12"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE15 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Message15"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_HARDWARE = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Hardware"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE18 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Message18"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Message20"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20.nested_types_by_name["Message1"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1.nested_types_by_name["Value"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE.nested_types_by_name[
-        "Message6"
-    ]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1 = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6.nested_types_by_name[
-    "Message1"
-]
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5 = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1.nested_types_by_name[
-    "Message5"
-]
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1 = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5.nested_types_by_name[
-    "Message1"
-]
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1_MESSAGE2 = _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1.nested_types_by_name[
-    "Message2"
-]
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE25 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Message25"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_LINKEDUSER = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["LinkedUser"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_STATE = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["State"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Message30"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30.nested_types_by_name["Message2"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2_MESSAGE2 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2.nested_types_by_name[
-        "Message2"
-    ]
-)
-_GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE34 = (
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE.nested_types_by_name["Message34"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE11 = _GETHOMEGRAPHRESPONSE_HOME.nested_types_by_name[
-    "Message11"
-]
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13 = _GETHOMEGRAPHRESPONSE_HOME.nested_types_by_name[
-    "Message13"
-]
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1 = (
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13.nested_types_by_name["Message1"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO = (
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1.nested_types_by_name["DeviceInfo"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO_AGENTINFO = (
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO.nested_types_by_name[
-        "AgentInfo"
-    ]
-)
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15 = _GETHOMEGRAPHRESPONSE_HOME.nested_types_by_name[
-    "Message15"
-]
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3 = (
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15.nested_types_by_name["Message3"]
-)
-_GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3_MESSAGE2 = (
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3.nested_types_by_name["Message2"]
-)
-_GETHOMEGRAPHRESPONSE_GROUP = _GETHOMEGRAPHRESPONSE.nested_types_by_name["Group"]
-_GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO = (
-    _GETHOMEGRAPHRESPONSE_GROUP.nested_types_by_name["DeviceInfo"]
-)
-_GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO_AGENTINFO = (
-    _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO.nested_types_by_name["AgentInfo"]
-)
-_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE12 = (
-    _GETHOMEGRAPHRESPONSE_GROUP.nested_types_by_name["Message12"]
-)
-_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE15 = (
-    _GETHOMEGRAPHRESPONSE_GROUP.nested_types_by_name["Message15"]
-)
-_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE17 = (
-    _GETHOMEGRAPHRESPONSE_GROUP.nested_types_by_name["Message17"]
-)
-_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE18 = (
-    _GETHOMEGRAPHRESPONSE_GROUP.nested_types_by_name["Message18"]
-)
-_GETHOMEGRAPHRESPONSE_GROUP_MESSAGE34 = (
-    _GETHOMEGRAPHRESPONSE_GROUP.nested_types_by_name["Message34"]
-)
-_GETHOMEGRAPHRESPONSE_ROOMTYPE = _GETHOMEGRAPHRESPONSE.nested_types_by_name["RoomType"]
-_GETHOMEGRAPHRESPONSE_DEVICETYPE = _GETHOMEGRAPHRESPONSE.nested_types_by_name[
-    "DeviceType"
-]
-_GETHOMEGRAPHRESPONSE_PROJECTTYPE = _GETHOMEGRAPHRESPONSE.nested_types_by_name[
-    "ProjectType"
-]
-_GETHOMEGRAPHRESPONSE_MESSAGE11 = _GETHOMEGRAPHRESPONSE.nested_types_by_name[
-    "Message11"
-]
-_GETHOMEGRAPHRESPONSE_MESSAGE11_MESSAGE2 = (
-    _GETHOMEGRAPHRESPONSE_MESSAGE11.nested_types_by_name["Message2"]
-)
-_GETHOMEGRAPHRESPONSE_LINKEDAPP = _GETHOMEGRAPHRESPONSE.nested_types_by_name[
-    "LinkedApp"
-]
-_GETASSISTANTDEVICESETTINGSREQUEST = DESCRIPTOR.message_types_by_name[
+] = _GETASSISTANTROUTINESRESPONSE
+DESCRIPTOR.message_types_by_name["GetHomeGraphRequest"] = _GETHOMEGRAPHREQUEST
+DESCRIPTOR.message_types_by_name["GetHomeGraphResponse"] = _GETHOMEGRAPHRESPONSE
+DESCRIPTOR.message_types_by_name[
     "GetAssistantDeviceSettingsRequest"
-]
-_GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO = (
-    _GETASSISTANTDEVICESETTINGSREQUEST.nested_types_by_name["DeviceInfo"]
-)
-_GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO = (
-    _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO.nested_types_by_name["AgentInfo"]
-)
-_GETASSISTANTDEVICESETTINGSRESPONSE = DESCRIPTOR.message_types_by_name[
+] = _GETASSISTANTDEVICESETTINGSREQUEST
+DESCRIPTOR.message_types_by_name[
     "GetAssistantDeviceSettingsResponse"
-]
-_GETASSISTANTDEVICESETTINGSRESPONSE_MESSAGE1 = (
-    _GETASSISTANTDEVICESETTINGSRESPONSE.nested_types_by_name["Message1"]
-)
-_UPDATEASSISTANTDEVICESETTINGSREQUEST = DESCRIPTOR.message_types_by_name[
+] = _GETASSISTANTDEVICESETTINGSRESPONSE
+DESCRIPTOR.message_types_by_name[
     "UpdateAssistantDeviceSettingsRequest"
-]
-_UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO = (
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST.nested_types_by_name["DeviceInfo"]
-)
-_UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO = (
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO.nested_types_by_name["AgentInfo"]
-)
-_UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA = (
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST.nested_types_by_name["UpdateData"]
-)
-_UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA_MESSAGE1 = (
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA.nested_types_by_name["Message1"]
-)
-_UPDATEASSISTANTDEVICESETTINGSRESPONSE = DESCRIPTOR.message_types_by_name[
+] = _UPDATEASSISTANTDEVICESETTINGSREQUEST
+DESCRIPTOR.message_types_by_name[
     "UpdateAssistantDeviceSettingsResponse"
-]
+] = _UPDATEASSISTANTDEVICESETTINGSRESPONSE
+_sym_db.RegisterFileDescriptor(DESCRIPTOR)
+
 GetAssistantRoutinesRequest = _reflection.GeneratedProtocolMessageType(
     "GetAssistantRoutinesRequest",
     (_message.Message,),
@@ -970,192 +6283,95 @@ UpdateAssistantDeviceSettingsResponse = _reflection.GeneratedProtocolMessageType
 )
 _sym_db.RegisterMessage(UpdateAssistantDeviceSettingsResponse)
 
-_HOMECONTROLSERVICE = DESCRIPTOR.services_by_name["HomeControlService"]
-_STRUCTURESSERVICE = DESCRIPTOR.services_by_name["StructuresService"]
-_HOMEDEVICESSERVICE = DESCRIPTOR.services_by_name["HomeDevicesService"]
-if _descriptor._USE_C_DESCRIPTORS == False:
 
-    DESCRIPTOR._options = None
-    _GETASSISTANTROUTINESREQUEST._serialized_start = 70
-    _GETASSISTANTROUTINESREQUEST._serialized_end = 99
-    _GETASSISTANTROUTINESRESPONSE._serialized_start = 102
-    _GETASSISTANTROUTINESRESPONSE._serialized_end = 986
-    _GETASSISTANTROUTINESRESPONSE_PART1._serialized_start = 293
-    _GETASSISTANTROUTINESRESPONSE_PART1._serialized_end = 943
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW._serialized_start = 453
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW._serialized_end = 943
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1._serialized_start = 579
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1._serialized_end = 943
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1._serialized_start = (
-        723
-    )
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1._serialized_end = (
-        943
-    )
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1_ROUTINE._serialized_start = (
-        878
-    )
-    _GETASSISTANTROUTINESRESPONSE_PART1_WORKFLOW_WF_SUB1_WF_SUB1_SUB1_ROUTINE._serialized_end = (
-        943
-    )
-    _GETASSISTANTROUTINESRESPONSE_PART2._serialized_start = 945
-    _GETASSISTANTROUTINESRESPONSE_PART2._serialized_end = 986
-    _GETHOMEGRAPHREQUEST._serialized_start = 988
-    _GETHOMEGRAPHREQUEST._serialized_end = 1040
-    _GETHOMEGRAPHRESPONSE._serialized_start = 1043
-    _GETHOMEGRAPHRESPONSE._serialized_end = 8143
-    _GETHOMEGRAPHRESPONSE_HOME._serialized_start = 1689
-    _GETHOMEGRAPHRESPONSE_HOME._serialized_end = 6751
-    _GETHOMEGRAPHRESPONSE_HOME_LOCATION._serialized_start = 2368
-    _GETHOMEGRAPHRESPONSE_HOME_LOCATION._serialized_end = 2585
-    _GETHOMEGRAPHRESPONSE_HOME_LOCATION_COORDINATES._serialized_start = 2535
-    _GETHOMEGRAPHRESPONSE_HOME_LOCATION_COORDINATES._serialized_end = 2585
-    _GETHOMEGRAPHRESPONSE_HOME_LINKEDUSER._serialized_start = 2587
-    _GETHOMEGRAPHRESPONSE_HOME_LINKEDUSER._serialized_end = 2622
-    _GETHOMEGRAPHRESPONSE_HOME_ROOM._serialized_start = 2625
-    _GETHOMEGRAPHRESPONSE_HOME_ROOM._serialized_end = 2783
-    _GETHOMEGRAPHRESPONSE_HOME_ROOM_CATEGORY._serialized_start = 2759
-    _GETHOMEGRAPHRESPONSE_HOME_ROOM_CATEGORY._serialized_end = 2783
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE._serialized_start = 2786
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE._serialized_end = 5917
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO._serialized_start = 4001
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO._serialized_end = 4194
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO_AGENTINFO._serialized_start = 4140
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_DEVICEINFO_AGENTINFO._serialized_end = 4194
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE12._serialized_start = 4196
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE12._serialized_end = 4309
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE15._serialized_start = 4311
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE15._serialized_end = 4378
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_HARDWARE._serialized_start = 4380
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_HARDWARE._serialized_end = 4405
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE18._serialized_start = 4407
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE18._serialized_end = 4439
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20._serialized_start = 4442
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20._serialized_end = 5474
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1._serialized_start = 4558
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1._serialized_end = 5474
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE._serialized_start = 4689
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE._serialized_end = 5474
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6._serialized_start = (
-        4816
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6._serialized_end = (
-        5474
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1._serialized_start = (
-        4955
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1._serialized_end = (
-        5474
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5._serialized_start = (
-        5104
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5._serialized_end = (
-        5474
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1._serialized_start = (
-        5262
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1._serialized_end = (
-        5474
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1_MESSAGE2._serialized_start = (
-        5449
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE20_MESSAGE1_VALUE_MESSAGE6_MESSAGE1_MESSAGE5_MESSAGE1_MESSAGE2._serialized_end = (
-        5474
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE25._serialized_start = 5476
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE25._serialized_end = 5517
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_LINKEDUSER._serialized_start = 2587
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_LINKEDUSER._serialized_end = 2622
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_STATE._serialized_start = 5556
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_STATE._serialized_end = 5592
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30._serialized_start = 5595
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30._serialized_end = 5889
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2._serialized_start = 5724
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2._serialized_end = 5889
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2_MESSAGE2._serialized_start = (
-        5449
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE30_MESSAGE2_MESSAGE2._serialized_end = 5474
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE34._serialized_start = 5891
-    _GETHOMEGRAPHRESPONSE_HOME_DEVICE_MESSAGE34._serialized_end = 5917
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE11._serialized_start = 5919
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE11._serialized_end = 5945
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13._serialized_start = 5948
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13._serialized_end = 6432
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1._serialized_start = 6105
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1._serialized_end = 6432
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO._serialized_start = 6227
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO._serialized_end = 6432
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO_AGENTINFO._serialized_start = (
-        4140
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE13_MESSAGE1_DEVICEINFO_AGENTINFO._serialized_end = (
-        4194
-    )
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15._serialized_start = 6435
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15._serialized_end = 6751
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3._serialized_start = 6591
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3._serialized_end = 6751
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3_MESSAGE2._serialized_start = 5724
-    _GETHOMEGRAPHRESPONSE_HOME_MESSAGE15_MESSAGE3_MESSAGE2._serialized_end = 5751
-    _GETHOMEGRAPHRESPONSE_GROUP._serialized_start = 6754
-    _GETHOMEGRAPHRESPONSE_GROUP._serialized_end = 7785
-    _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO._serialized_start = 7389
-    _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO._serialized_end = 7557
-    _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO_AGENTINFO._serialized_start = 4140
-    _GETHOMEGRAPHRESPONSE_GROUP_DEVICEINFO_AGENTINFO._serialized_end = 4194
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE12._serialized_start = 7559
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE12._serialized_end = 7632
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE15._serialized_start = 7634
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE15._serialized_end = 7690
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE17._serialized_start = 7692
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE17._serialized_end = 7724
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE18._serialized_start = 7726
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE18._serialized_end = 7757
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE34._serialized_start = 5891
-    _GETHOMEGRAPHRESPONSE_GROUP_MESSAGE34._serialized_end = 5917
-    _GETHOMEGRAPHRESPONSE_ROOMTYPE._serialized_start = 7787
-    _GETHOMEGRAPHRESPONSE_ROOMTYPE._serialized_end = 7825
-    _GETHOMEGRAPHRESPONSE_DEVICETYPE._serialized_start = 7827
-    _GETHOMEGRAPHRESPONSE_DEVICETYPE._serialized_end = 7867
-    _GETHOMEGRAPHRESPONSE_PROJECTTYPE._serialized_start = 7869
-    _GETHOMEGRAPHRESPONSE_PROJECTTYPE._serialized_end = 7910
-    _GETHOMEGRAPHRESPONSE_MESSAGE11._serialized_start = 7913
-    _GETHOMEGRAPHRESPONSE_MESSAGE11._serialized_end = 8054
-    _GETHOMEGRAPHRESPONSE_MESSAGE11_MESSAGE2._serialized_start = 8030
-    _GETHOMEGRAPHRESPONSE_MESSAGE11_MESSAGE2._serialized_end = 8054
-    _GETHOMEGRAPHRESPONSE_LINKEDAPP._serialized_start = 8056
-    _GETHOMEGRAPHRESPONSE_LINKEDAPP._serialized_end = 8143
-    _GETASSISTANTDEVICESETTINGSREQUEST._serialized_start = 8146
-    _GETASSISTANTDEVICESETTINGSREQUEST._serialized_end = 8493
-    _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO._serialized_start = 8299
-    _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO._serialized_end = 8493
-    _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO._serialized_start = 4140
-    _GETASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO._serialized_end = 4194
-    _GETASSISTANTDEVICESETTINGSRESPONSE._serialized_start = 8496
-    _GETASSISTANTDEVICESETTINGSRESPONSE._serialized_end = 8726
-    _GETASSISTANTDEVICESETTINGSRESPONSE_MESSAGE1._serialized_start = 8628
-    _GETASSISTANTDEVICESETTINGSRESPONSE_MESSAGE1._serialized_end = 8726
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST._serialized_start = 8729
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST._serialized_end = 9404
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO._serialized_start = 8989
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO._serialized_end = 9186
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO._serialized_start = 4140
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_DEVICEINFO_AGENTINFO._serialized_end = 4194
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA._serialized_start = 9189
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA._serialized_end = 9404
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA_MESSAGE1._serialized_start = 9310
-    _UPDATEASSISTANTDEVICESETTINGSREQUEST_UPDATEDATA_MESSAGE1._serialized_end = 9404
-    _UPDATEASSISTANTDEVICESETTINGSRESPONSE._serialized_start = 9406
-    _UPDATEASSISTANTDEVICESETTINGSRESPONSE._serialized_end = 9462
-    _HOMECONTROLSERVICE._serialized_start = 9465
-    _HOMECONTROLSERVICE._serialized_end = 9633
-    _STRUCTURESSERVICE._serialized_start = 9636
-    _STRUCTURESSERVICE._serialized_end = 9776
-    _HOMEDEVICESSERVICE._serialized_start = 9779
-    _HOMEDEVICESSERVICE._serialized_end = 10140
+_HOMECONTROLSERVICE = _descriptor.ServiceDescriptor(
+    name="HomeControlService",
+    full_name="google.internal.home.foyer.v1.HomeControlService",
+    file=DESCRIPTOR,
+    index=0,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+    serialized_start=9465,
+    serialized_end=9633,
+    methods=[
+        _descriptor.MethodDescriptor(
+            name="GetAssistantRoutines",
+            full_name="google.internal.home.foyer.v1.HomeControlService.GetAssistantRoutines",
+            index=0,
+            containing_service=None,
+            input_type=_GETASSISTANTROUTINESREQUEST,
+            output_type=_GETASSISTANTROUTINESRESPONSE,
+            serialized_options=None,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+)
+_sym_db.RegisterServiceDescriptor(_HOMECONTROLSERVICE)
+
+DESCRIPTOR.services_by_name["HomeControlService"] = _HOMECONTROLSERVICE
+
+
+_STRUCTURESSERVICE = _descriptor.ServiceDescriptor(
+    name="StructuresService",
+    full_name="google.internal.home.foyer.v1.StructuresService",
+    file=DESCRIPTOR,
+    index=1,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+    serialized_start=9636,
+    serialized_end=9776,
+    methods=[
+        _descriptor.MethodDescriptor(
+            name="GetHomeGraph",
+            full_name="google.internal.home.foyer.v1.StructuresService.GetHomeGraph",
+            index=0,
+            containing_service=None,
+            input_type=_GETHOMEGRAPHREQUEST,
+            output_type=_GETHOMEGRAPHRESPONSE,
+            serialized_options=None,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+)
+_sym_db.RegisterServiceDescriptor(_STRUCTURESSERVICE)
+
+DESCRIPTOR.services_by_name["StructuresService"] = _STRUCTURESSERVICE
+
+
+_HOMEDEVICESSERVICE = _descriptor.ServiceDescriptor(
+    name="HomeDevicesService",
+    full_name="google.internal.home.foyer.v1.HomeDevicesService",
+    file=DESCRIPTOR,
+    index=2,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+    serialized_start=9779,
+    serialized_end=10140,
+    methods=[
+        _descriptor.MethodDescriptor(
+            name="GetAssistantDeviceSettings",
+            full_name="google.internal.home.foyer.v1.HomeDevicesService.GetAssistantDeviceSettings",
+            index=0,
+            containing_service=None,
+            input_type=_GETASSISTANTDEVICESETTINGSREQUEST,
+            output_type=_GETASSISTANTDEVICESETTINGSRESPONSE,
+            serialized_options=None,
+            create_key=_descriptor._internal_create_key,
+        ),
+        _descriptor.MethodDescriptor(
+            name="UpdateAssistantDeviceSettings",
+            full_name="google.internal.home.foyer.v1.HomeDevicesService.UpdateAssistantDeviceSettings",
+            index=1,
+            containing_service=None,
+            input_type=_UPDATEASSISTANTDEVICESETTINGSREQUEST,
+            output_type=_UPDATEASSISTANTDEVICESETTINGSRESPONSE,
+            serialized_options=None,
+            create_key=_descriptor._internal_create_key,
+        ),
+    ],
+)
+_sym_db.RegisterServiceDescriptor(_HOMEDEVICESSERVICE)
+
+DESCRIPTOR.services_by_name["HomeDevicesService"] = _HOMEDEVICESSERVICE
+
 # @@protoc_insertion_point(module_scope)

--- a/poetry.lock
+++ b/poetry.lock
@@ -316,15 +316,15 @@ protobuf = ["grpcio-tools (>=1.47.0)"]
 
 [[package]]
 name = "grpcio-tools"
-version = "1.47.0"
+version = "1.43.0"
 description = "Protobuf code generator for gRPC"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-grpcio = ">=1.47.0"
-protobuf = ">=3.12.0,<4.0dev"
+grpcio = ">=1.43.0"
+protobuf = ">=3.5.0.post1,<4.0dev"
 
 [[package]]
 name = "identify"
@@ -627,11 +627,11 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "3.19.4"
+version = "3.20.1"
 description = "Protocol Buffers"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 
 [[package]]
 name = "ptyprocess"
@@ -936,7 +936,7 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ce1ab1ac3b0858afcb50e336a253c395acbdab053daec187b86489ba9399f3ea"
+content-hash = "d2776f39c5f7dcd65a4727ddab27321b90c764e23023bd03ca1ef5fb3cade8b0"
 
 [metadata.files]
 appnope = [
@@ -967,31 +967,7 @@ backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
 ]
-black = [
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
-    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
-    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
-    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
-    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
-    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
-    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
-    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
-    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
-    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
-    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
-    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
-    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
-    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
-    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
-    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
-    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
-    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
-    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
-    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
-    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
-]
+black = []
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
@@ -1044,10 +1020,7 @@ flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
-flake8-bugbear = [
-    {file = "flake8-bugbear-22.7.1.tar.gz", hash = "sha256:e450976a07e4f9d6c043d4f72b17ec1baf717fe37f7997009c8ae58064f88305"},
-    {file = "flake8_bugbear-22.7.1-py3-none-any.whl", hash = "sha256:db5d7a831ef4412a224b26c708967ff816818cabae415e76b8c58df156c4b8e5"},
-]
+flake8-bugbear = []
 flake8-comprehensions = [
     {file = "flake8-comprehensions-3.10.0.tar.gz", hash = "sha256:181158f7e7aa26a63a0a38e6017cef28c6adee71278ce56ce11f6ec9c4905058"},
     {file = "flake8_comprehensions-3.10.0-py3-none-any.whl", hash = "sha256:dad454fd3d525039121e98fa1dd90c46bc138708196a4ebbc949ad3c859adedb"},
@@ -1063,10 +1036,7 @@ gpsoauth = [
     {file = "gpsoauth-1.0.2-py3-none-any.whl", hash = "sha256:8f195b5f30df3109a79e6c8d45f2bd45c0fe64dfef7a5abc033bc6508f961abf"},
     {file = "gpsoauth-1.0.2.tar.gz", hash = "sha256:ebcae72eb325a7f06cbea95b9d5e64bec25370312db15e8e2e46c4d54e729e7a"},
 ]
-grpc-stubs = [
-    {file = "grpc-stubs-1.24.11.tar.gz", hash = "sha256:b02b0445b264eb3d310a2c14816c440f98f76d4ba2a5746adf148d57cca8b3a5"},
-    {file = "grpc_stubs-1.24.11-py3-none-any.whl", hash = "sha256:56d8f241c4b309c7c712d916be0e0c7b8b72b00cc61c0c08a4b50e1c13fd26e3"},
-]
+grpc-stubs = []
 grpcio = [
     {file = "grpcio-1.47.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:544da3458d1d249bb8aed5504adf3e194a931e212017934bf7bfa774dad37fb3"},
     {file = "grpcio-1.47.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:b88bec3f94a16411a1e0336eb69f335f58229e45d4082b12d8e554cedea97586"},
@@ -1116,52 +1086,50 @@ grpcio = [
     {file = "grpcio-1.47.0.tar.gz", hash = "sha256:5dbba95fab9b35957b4977b8904fc1fa56b302f9051eff4d7716ebb0c087f801"},
 ]
 grpcio-tools = [
-    {file = "grpcio-tools-1.47.0.tar.gz", hash = "sha256:f64b5378484be1d6ce59311f86174be29c8ff98d8d90f589e1c56d5acae67d3c"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:3edb04d102e0d6f0149d93fe8cf69a38c20a2259a913701a4c35c119049c8404"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:dd5d330230038374e64fc652fc4c1b25d457a8b67b9069bfce83a17ab675650b"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:498c0bae4975683a5a33b72cf1bd64703b34c826871fd3ee8d295407cd5211ec"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1de1f139f05ab6bbdabc58b06f6ebb5940a92214bbc7246270299387d0af2ae"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fccc282ee97211a33652419dcdfd24a9a60bbd2d56f5c5dd50c7186a0f4d978"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:441a0a378117447c089b944f325f11039329d8aa961ecdb8226c5dd84af6f003"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0eced69e159b3fdd7597d85950f56990e0aa81c11a20a7785fb66f0e47c46b57"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-win32.whl", hash = "sha256:2c5c50886e6e79af5387c6514eb19f1f6b1a0b4eb787f1b7a8f21a74e2444102"},
-    {file = "grpcio_tools-1.47.0-cp310-cp310-win_amd64.whl", hash = "sha256:156b5f6654fea51983fd9257d47f1ad7bfb2a1d09ed471e610a7b34b97d40802"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:94114e01c4508d904825bd984e3d2752c0b0e6eb714ac08b99f73421691cf931"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:51352070f13ea3346b5f5ca825f2203528b8218fffc6ac6d951216f812272d8b"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:53c47b08ee2f59a89e8df5f3c09850d7fac264754cbaeabae65f6fbf78d80536"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:818fca1c7dd4ad1c9c01f91ba37006964f4c57c93856fa4ebd7d5589132844d6"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2364ac3bd7266752c9971dbef3f79d21cd958777823512faa93473cbd973b8f1"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:9dd6e26e3e0555deadcb52b087c6064e4fd02c09180b42e96c66260137d26b50"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:a93263955da8d6e449d7ceb84af4e84b82fa760fd661b4ef4549929d9670ab8e"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-win32.whl", hash = "sha256:6804cbd92b9069ae9189d65300e456bcc3945f6ae196d2af254e9635b9c3ef0d"},
-    {file = "grpcio_tools-1.47.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7589d6f56e633378047274223f0a75534b2cd7c598f9f2894cb4854378b8b00b"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:6d41ec06f2ccc8adcd400a63508ea8e008fb03f270e0031ff2de047def2ada9d"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:74f607b9084b5325a997d9ae57c0814955e19311111568d029b2a6a66f4869ec"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:7fd10683f4f03400536e7a026de9929430ee198c2cbdf2c584edfa909ccc8993"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7be45d69f0eed912df2e92d94958d1a3e72617469ec58ffcac3e2eb153a7057e"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca548afcfa0ffc47c3cf9eeede81adde15c321bfe897085e90ce8913615584ae"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f19191460435f8bc72450cf26ac0559726f98c49ad9b0969db3db8ba51be98c8"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b2fa3c545c8aa1e8c33ca04b1424be3ff77da631faf37db3350d7459c3bdedde"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-win32.whl", hash = "sha256:0b32002ff4ae860c85feb2aca1b752eb4518e7781c5770b869e7b2dfa9d92cbe"},
-    {file = "grpcio_tools-1.47.0-cp37-cp37m-win_amd64.whl", hash = "sha256:5c8ab9b541a869d3b4ef34c291fbfb6ec78ad728e04737fddd91eac3c2193459"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:05b495ed997a9afc9016c696ed7fcd35678a7276fe0bd8b95743a382363ad2b4"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:6c66094fd79ee98bcb504e9f1a3fa6e7ebfd246b4e3d8132227e5020b5633988"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:84e38f46af513a6f62a3d482160fcb94063dbc9fdd1452d09f8010422f144de1"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:058060fbc5a60a1c6cc2cbb3d99f730825ba249917978d48b7d0fd8f2caf01da"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc6567d652c6b70d8c03f4e450a694e62b4d69a400752f8b9c3c8b659dd6b06a"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9ab78cd16b4ac7c6b79c8be194c67e03238f6378694133ce3ce9b123caf24ed5"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ccc8ce33bd31bf12649541b5857fabfee7dd84b04138336a27bf46a28d150c11"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-win32.whl", hash = "sha256:4eced9e0674bfb5c528a3bf2ea2b8596da133148b3e0718915792074204ea226"},
-    {file = "grpcio_tools-1.47.0-cp38-cp38-win_amd64.whl", hash = "sha256:45ceb73a97e2d7ff719fc12c02f1ef13014c47bad60a864313da88ccd90cdf36"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:ac5c6aef72618ebc5ee9ad725dd53e1c145ef420b79d21a7c43ca80658d3d8d4"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:c2c280197d68d5a28f5b90adf755bd9e28c99f3e47ad4edcfe20497cf3456e1d"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:93d08c02bd82e423353399582f22493a191db459c3f34031b583f13bcf42b95e"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18548f35b0657422d5d40e6fa89994469f4bb77df09f8133ecdccec0e31fc72c"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb44ae747fd299b6513420cb6ead50491dc3691d17da48f28fcc5ebf07f47741"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ae53ae35a9761ceea50a502addb7186c5188969d63ad21cf12e00d939db5b967"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2a6a6e5e08866d643b84c89140bbe504f864f11b87bfff7a5f2af94c5a2be18d"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-win32.whl", hash = "sha256:759064fc8439bbfe5402b2fd3b0685f4ffe07d7cc6a64908c2f88a7c80449ce4"},
-    {file = "grpcio_tools-1.47.0-cp39-cp39-win_amd64.whl", hash = "sha256:1a0a91941f6f2a4d97e843a5d9ad7ccccf702af2d9455932f18cf922e65af95e"},
+    {file = "grpcio-tools-1.43.0.tar.gz", hash = "sha256:f42f1d713096808b1b0472dd2a3749b712d13f0092dab9442d9c096446e860b2"},
+    {file = "grpcio_tools-1.43.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:766771ef5b60ebcba0a3bdb302dd92fda988552eb8508451ff6d97371eac38e5"},
+    {file = "grpcio_tools-1.43.0-cp310-cp310-macosx_10_10_universal2.whl", hash = "sha256:178a881db5de0f89abf3aeeb260ecfd1116cc31f88fb600a45fb5b19c3323b33"},
+    {file = "grpcio_tools-1.43.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:019f55929e963214471825c7a4cdab7a57069109d5621b24e4db7b428b5fe47d"},
+    {file = "grpcio_tools-1.43.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6c0e1d1b47554c580882d392b739df91a55b6a8ec696b2b2e1bbc127d63df2c"},
+    {file = "grpcio_tools-1.43.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c5c80098fa69593b828d119973744de03c3f9a6935df8a02e4329a39b7072f5"},
+    {file = "grpcio_tools-1.43.0-cp310-cp310-win32.whl", hash = "sha256:53f7dcaa4218df1b64b39d0fc7236a8270e8ab2db4ab8cd1d2fda0e6d4544946"},
+    {file = "grpcio_tools-1.43.0-cp310-cp310-win_amd64.whl", hash = "sha256:5be6d402b0cafef20ba3abb3baa37444961d9a9c4a6434d3d7c1f082f7697deb"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-linux_armv7l.whl", hash = "sha256:8953fdebef6905d7ff13a5a376b21b6fecd808d18bf4f0d3990ffe4a215d56eb"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:18870dcc8369ac4c37213e6796d8dc20494ea770670204f5e573f88e69eaaf0b"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:010a4be6a2fccbd6741a4809c5da7f2e39a1e9e227745e6b495be567638bbeb9"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:426f16b6b14d533ce61249a18fbcd1a23a4fa0c71a6d7ab347b1c7f862847bb8"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-manylinux_2_17_aarch64.whl", hash = "sha256:f974cb0bea88bac892c3ed16da92c6ac88cff0fea17f24bf0e1892eb4d27cd00"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:55c2e604536e06248e2f81e549737fb3a180c8117832e494a0a8a81fbde44837"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f97f9ffa49348fb24692751d2d4455ef2968bd07fe536d65597caaec14222629"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-win32.whl", hash = "sha256:6eaf97414237b8670ae9fa623879a26eabcc4c635b550c79a81e17eb600d6ae3"},
+    {file = "grpcio_tools-1.43.0-cp36-cp36m-win_amd64.whl", hash = "sha256:04f100c1f6a7c72c537760c33582f6970070bd6fa6676b529bccfa31cc58bc79"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:9dbb6d1f58f26d88ae689f1b49de84cfaf4786c81c01b9001d3ceea178116a07"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:63862a441a77f6326ea9fe4bb005882f0e363441a5968d9cf8621c34d3dadc2b"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6dea0cb2e79b67593553ed8662f70e4310599fa8850fc0e056b19fcb63572b7f"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3eb4aa5b0e578c3d9d9da8e37a2ef73654287a498b8081543acd0db7f0ec1a9c"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:09464c6b17663088144b7e6ea10e9465efdcee03d4b2ffefab39a799bd8360f8"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2458d6b0404f83d95aef00cec01f310d30e9719564a25be50e39b259f6a2da5d"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e9bb5da437364b7dcd2d3c6850747081ecbec0ba645c96c6d471f7e21fdcadb"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-win32.whl", hash = "sha256:2737f749a6ab965748629e619b35f3e1cbe5820fc79e34c88f73cb99efc71dde"},
+    {file = "grpcio_tools-1.43.0-cp37-cp37m-win_amd64.whl", hash = "sha256:c39cbe7b902bb92f9afaa035091f5e2b8be35acbac501fec8cb6a0be7d7cdbbd"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:05550ba473cff7c09e905fcfb2263fd1f7600389660194ec022b5d5a3802534b"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:ce13a922db8f5f95c5041d3a4cbf04d942b353f0cba9b251a674f69a31a2d3a6"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:f19d40690c97365c1c1bde81474e6f496d7ab76f87e6d2889c72ad01bac98f2d"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:ba3da574eb08fcaed541b3fc97ce217360fd86d954fa9ad6a604803d57a2e049"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:efd1eb5880001f5189cfa3a774675cc9bbc8cc51586a3e90fe796394ac8626b8"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:234c7a5af653357df5c616e013173eddda6193146c8ab38f3108c4784f66be26"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7e3662f62d410b3f81823b5fa0f79c6e0e250977a1058e4131867b85138a661"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-win32.whl", hash = "sha256:5f2e584d7644ef924e9e042fa151a3bb9f7c28ef1ae260ee6c9cb327982b5e94"},
+    {file = "grpcio_tools-1.43.0-cp38-cp38-win_amd64.whl", hash = "sha256:98dcb5b756855110fb661ccd6a93a716610b7efcd5720a3aec01358a1a892c30"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:61ef6cb6ccf9b9c27bb85fffc5338194bcf444df502196c2ad0ff8df4706d41e"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:1def9b68ac9e62674929bc6590a33d89635f1cf16016657d9e16a69f41aa5c36"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:b68cc0c95a0f8c757e8d69b5fa46111d5c9d887ae62af28f827649b1d1b70fe1"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:e956b5c3b586d7b27eae49fb06f544a26288596fe12e22ffec768109717276d1"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:671e61bbc91d8d568f12c3654bb5a91fce9f3fdfd5ec2cfc60c2d3a840449aa6"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d7173ed19854d1066bce9bdc09f735ca9c13e74a25d47a1cc5d1fe803b53bffb"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1adb0dbcc1c10b86dcda910b8f56e39210e401bcee923dba166ba923a5f4696a"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-win32.whl", hash = "sha256:ebfb94ddb454a6dc3a505d9531dc81c948e6364e181b8795bfad3f3f479974dc"},
+    {file = "grpcio_tools-1.43.0-cp39-cp39-win_amd64.whl", hash = "sha256:d21928b680e6e29538688cffbf53f3d5a53cff0ec8f0c33139641700045bdf1a"},
 ]
 identify = [
     {file = "identify-2.4.11-py2.py3-none-any.whl", hash = "sha256:fd906823ed1db23c7a48f9b176a1d71cb8abede1e21ebe614bac7bdd688d9213"},
@@ -1310,41 +1278,36 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-pre-commit = [
-    {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
-    {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
-]
+pre-commit = []
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.28-py3-none-any.whl", hash = "sha256:30129d870dcb0b3b6a53efdc9d0a83ea96162ffd28ffe077e94215b233dc670c"},
     {file = "prompt_toolkit-3.0.28.tar.gz", hash = "sha256:9f1cd16b1e86c2968f2519d7fb31dd9d669916f515612c269d14e9ed52b51650"},
 ]
 protobuf = [
-    {file = "protobuf-3.19.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f51d5a9f137f7a2cec2d326a74b6e3fc79d635d69ffe1b036d39fc7d75430d37"},
-    {file = "protobuf-3.19.4-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:09297b7972da685ce269ec52af761743714996b4381c085205914c41fcab59fb"},
-    {file = "protobuf-3.19.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:072fbc78d705d3edc7ccac58a62c4c8e0cec856987da7df8aca86e647be4e35c"},
-    {file = "protobuf-3.19.4-cp310-cp310-win32.whl", hash = "sha256:7bb03bc2873a2842e5ebb4801f5c7ff1bfbdf426f85d0172f7644fcda0671ae0"},
-    {file = "protobuf-3.19.4-cp310-cp310-win_amd64.whl", hash = "sha256:f358aa33e03b7a84e0d91270a4d4d8f5df6921abe99a377828839e8ed0c04e07"},
-    {file = "protobuf-3.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1c91ef4110fdd2c590effb5dca8fdbdcb3bf563eece99287019c4204f53d81a4"},
-    {file = "protobuf-3.19.4-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c438268eebb8cf039552897d78f402d734a404f1360592fef55297285f7f953f"},
-    {file = "protobuf-3.19.4-cp36-cp36m-win32.whl", hash = "sha256:835a9c949dc193953c319603b2961c5c8f4327957fe23d914ca80d982665e8ee"},
-    {file = "protobuf-3.19.4-cp36-cp36m-win_amd64.whl", hash = "sha256:4276cdec4447bd5015453e41bdc0c0c1234eda08420b7c9a18b8d647add51e4b"},
-    {file = "protobuf-3.19.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6cbc312be5e71869d9d5ea25147cdf652a6781cf4d906497ca7690b7b9b5df13"},
-    {file = "protobuf-3.19.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:54a1473077f3b616779ce31f477351a45b4fef8c9fd7892d6d87e287a38df368"},
-    {file = "protobuf-3.19.4-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:435bb78b37fc386f9275a7035fe4fb1364484e38980d0dd91bc834a02c5ec909"},
-    {file = "protobuf-3.19.4-cp37-cp37m-win32.whl", hash = "sha256:16f519de1313f1b7139ad70772e7db515b1420d208cb16c6d7858ea989fc64a9"},
-    {file = "protobuf-3.19.4-cp37-cp37m-win_amd64.whl", hash = "sha256:cdc076c03381f5c1d9bb1abdcc5503d9ca8b53cf0a9d31a9f6754ec9e6c8af0f"},
-    {file = "protobuf-3.19.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:69da7d39e39942bd52848438462674c463e23963a1fdaa84d88df7fbd7e749b2"},
-    {file = "protobuf-3.19.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:48ed3877fa43e22bcacc852ca76d4775741f9709dd9575881a373bd3e85e54b2"},
-    {file = "protobuf-3.19.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd95d1dfb9c4f4563e6093a9aa19d9c186bf98fa54da5252531cc0d3a07977e7"},
-    {file = "protobuf-3.19.4-cp38-cp38-win32.whl", hash = "sha256:b38057450a0c566cbd04890a40edf916db890f2818e8682221611d78dc32ae26"},
-    {file = "protobuf-3.19.4-cp38-cp38-win_amd64.whl", hash = "sha256:7ca7da9c339ca8890d66958f5462beabd611eca6c958691a8fe6eccbd1eb0c6e"},
-    {file = "protobuf-3.19.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:36cecbabbda242915529b8ff364f2263cd4de7c46bbe361418b5ed859677ba58"},
-    {file = "protobuf-3.19.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c1068287025f8ea025103e37d62ffd63fec8e9e636246b89c341aeda8a67c934"},
-    {file = "protobuf-3.19.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96bd766831596d6014ca88d86dc8fe0fb2e428c0b02432fd9db3943202bf8c5e"},
-    {file = "protobuf-3.19.4-cp39-cp39-win32.whl", hash = "sha256:84123274d982b9e248a143dadd1b9815049f4477dc783bf84efe6250eb4b836a"},
-    {file = "protobuf-3.19.4-cp39-cp39-win_amd64.whl", hash = "sha256:3112b58aac3bac9c8be2b60a9daf6b558ca3f7681c130dcdd788ade7c9ffbdca"},
-    {file = "protobuf-3.19.4-py2.py3-none-any.whl", hash = "sha256:8961c3a78ebfcd000920c9060a262f082f29838682b1f7201889300c1fbe0616"},
-    {file = "protobuf-3.19.4.tar.gz", hash = "sha256:9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a"},
+    {file = "protobuf-3.20.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3cc797c9d15d7689ed507b165cd05913acb992d78b379f6014e013f9ecb20996"},
+    {file = "protobuf-3.20.1-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:ff8d8fa42675249bb456f5db06c00de6c2f4c27a065955917b28c4f15978b9c3"},
+    {file = "protobuf-3.20.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cd68be2559e2a3b84f517fb029ee611546f7812b1fdd0aa2ecc9bc6ec0e4fdde"},
+    {file = "protobuf-3.20.1-cp310-cp310-win32.whl", hash = "sha256:9016d01c91e8e625141d24ec1b20fed584703e527d28512aa8c8707f105a683c"},
+    {file = "protobuf-3.20.1-cp310-cp310-win_amd64.whl", hash = "sha256:32ca378605b41fd180dfe4e14d3226386d8d1b002ab31c969c366549e66a2bb7"},
+    {file = "protobuf-3.20.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9be73ad47579abc26c12024239d3540e6b765182a91dbc88e23658ab71767153"},
+    {file = "protobuf-3.20.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:097c5d8a9808302fb0da7e20edf0b8d4703274d140fd25c5edabddcde43e081f"},
+    {file = "protobuf-3.20.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e250a42f15bf9d5b09fe1b293bdba2801cd520a9f5ea2d7fb7536d4441811d20"},
+    {file = "protobuf-3.20.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cdee09140e1cd184ba9324ec1df410e7147242b94b5f8b0c64fc89e38a8ba531"},
+    {file = "protobuf-3.20.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:af0ebadc74e281a517141daad9d0f2c5d93ab78e9d455113719a45a49da9db4e"},
+    {file = "protobuf-3.20.1-cp37-cp37m-win32.whl", hash = "sha256:755f3aee41354ae395e104d62119cb223339a8f3276a0cd009ffabfcdd46bb0c"},
+    {file = "protobuf-3.20.1-cp37-cp37m-win_amd64.whl", hash = "sha256:62f1b5c4cd6c5402b4e2d63804ba49a327e0c386c99b1675c8a0fefda23b2067"},
+    {file = "protobuf-3.20.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:06059eb6953ff01e56a25cd02cca1a9649a75a7e65397b5b9b4e929ed71d10cf"},
+    {file = "protobuf-3.20.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:cb29edb9eab15742d791e1025dd7b6a8f6fcb53802ad2f6e3adcb102051063ab"},
+    {file = "protobuf-3.20.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:69ccfdf3657ba59569c64295b7d51325f91af586f8d5793b734260dfe2e94e2c"},
+    {file = "protobuf-3.20.1-cp38-cp38-win32.whl", hash = "sha256:dd5789b2948ca702c17027c84c2accb552fc30f4622a98ab5c51fcfe8c50d3e7"},
+    {file = "protobuf-3.20.1-cp38-cp38-win_amd64.whl", hash = "sha256:77053d28427a29987ca9caf7b72ccafee011257561259faba8dd308fda9a8739"},
+    {file = "protobuf-3.20.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6f50601512a3d23625d8a85b1638d914a0970f17920ff39cec63aaef80a93fb7"},
+    {file = "protobuf-3.20.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:284f86a6207c897542d7e956eb243a36bb8f9564c1742b253462386e96c6b78f"},
+    {file = "protobuf-3.20.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7403941f6d0992d40161aa8bb23e12575637008a5a02283a930addc0508982f9"},
+    {file = "protobuf-3.20.1-cp39-cp39-win32.whl", hash = "sha256:db977c4ca738dd9ce508557d4fce0f5aebd105e158c725beec86feb1f6bc20d8"},
+    {file = "protobuf-3.20.1-cp39-cp39-win_amd64.whl", hash = "sha256:7e371f10abe57cee5021797126c93479f59fccc9693dafd6bd5633ab67808a91"},
+    {file = "protobuf-3.20.1-py2.py3-none-any.whl", hash = "sha256:adfc6cf69c7f8c50fd24c793964eef18f0ac321315439d94945820612849c388"},
+    {file = "protobuf-3.20.1.tar.gz", hash = "sha256:adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -1399,10 +1362,7 @@ pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
-pylint = [
-    {file = "pylint-2.14.5-py3-none-any.whl", hash = "sha256:fabe30000de7d07636d2e82c9a518ad5ad7908590fe135ace169b44839c15f90"},
-    {file = "pylint-2.14.5.tar.gz", hash = "sha256:487ce2192eee48211269a0e976421f334cf94de1806ca9d0a99449adcdf0285e"},
-]
+pylint = []
 pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
     {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
@@ -1450,10 +1410,7 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
-requests = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
-]
+requests = []
 simplejson = [
     {file = "simplejson-3.17.6-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a89acae02b2975b1f8e4974cb8cdf9bf9f6c91162fb8dec50c259ce700f2770a"},
     {file = "simplejson-3.17.6-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:82ff356ff91be0ab2293fc6d8d262451eb6ac4fd999244c4b5f863e049ba219c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,8 @@ repository = "https://github.com/leikoilja/glocaltokens"
 [tool.poetry.dependencies]
 python = "^3.8"
 gpsoauth = "^1.0.1"
+protobuf = "^3.20.1"
 simplejson = "^3.17.2"
-# Version used for generating stubs.
-protobuf = "3.19.4"
 # Note, we want to keep versions of grpcio, requests and zeroconf similar to Home Assistant
 # https://github.com/home-assistant/core/blob/2022.6.0/homeassistant/package_constraints.txt
 grpcio = "^1.46.1"
@@ -44,7 +43,8 @@ flake8-comprehensions = "^3.4.0"
 flake8-simplify = "^0.19.2"
 flake8-use-fstring = "^1.3"
 grpc-stubs = "^1.24.10"
-grpcio-tools = "^1.46.1"
+# Using newer version will cause compatibility issues with google-wifi integration.
+grpcio-tools = "1.43.0"
 ipdb = "^0.13.7"
 isort = "^5.10.1"
 mock = "^4.0.3"


### PR DESCRIPTION
Restore `v1_pb2.py` before #262 to fix compatibility issues with Google Wifi integration.

This requires downgrading `grpcio-tools` to 1.43.0.

Also relax requirement on `protobuf` version, it doesn't really matter.