### PR TITLE
Update dependabot config for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    allow:
-      - dependency-type: development
     labels:
       - "dependencies"
   - package-ecosystem: github-actions


### PR DESCRIPTION
It seems this setting is not supported for uv.