### PR TITLE
Add fallback version for dependabot build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,3 @@ updates:
       interval: daily
     labels:
       - "dependencies"
-    ignore:
-      - dependency-name: "crazy-max/ghaction-github-labeler"
-        versions: ["5.1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ dev = [
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0"
+
 [tool.ruff]
 required-version = ">=0.6.0"
 target-version = "py39"


### PR DESCRIPTION
Dependabot doesn't work well with dynamic version: https://github.com/dependabot/dependabot-core/issues/12340

This should help for build to pass, at least further.